### PR TITLE
feat: add pathfinding for mouse navigation

### DIFF
--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -18,6 +18,7 @@ import game.keyhandler.KeyHandler;
 import game.mouseclick.MouseHandler;
 import game.object.ObjectManager;
 import game.object.SuperObject;
+import game.pathfinding.PathFinder;
 import game.tile.TileManager;
 import game.ui.Ui;
 
@@ -42,7 +43,8 @@ public class GamePanel extends JPanel implements Runnable {
 	private Thread thread;
 	private int FPS = 60;
 	public KeyHandler keyH = new KeyHandler(this);
-	MouseHandler mounseH = new MouseHandler(this);
+        MouseHandler mounseH = new MouseHandler(this);
+        private final PathFinder pathFinder = new PathFinder(this);
 	private final Player player = new Player(this);
 	private final TileManager tileManager = new TileManager(this);
 	private final CollisionChecker checkCollision = new CollisionChecker(this);
@@ -153,10 +155,12 @@ public class GamePanel extends JPanel implements Runnable {
 	public int getWorldHeight() { return worldHeight; }
 	public Player getPlayer() { return player; }
 	public TileManager getTileManager() { return tileManager; }
-	public CollisionChecker getCheckCollision() { return checkCollision; }
-	public ObjectManager getObjectManager() { return objectManager; } 
-	public List<SuperObject> getObjects() { return objects; }
-	public List<Entity> getNpcs() { return npcs; }
+        public CollisionChecker getCheckCollision() { return checkCollision; }
+        public ObjectManager getObjectManager() { return objectManager; }
+        public List<SuperObject> getObjects() { return objects; }
+        public List<Entity> getNpcs() { return npcs; }
+        public MouseHandler getMouseH() { return mounseH; }
+        public PathFinder getPathFinder() { return pathFinder; }
 
 	public int getGameState() { return gameState; }
 	public GamePanel setGameState(int gameState) { this.gameState = gameState; return this; }

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -23,10 +23,11 @@ public class MouseHandler implements MouseListener {
 	        int worldX = gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() + mouseX;
 	        int worldY = gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() + mouseY;
 	        // Lưu điểm đích trong thế giới
-	        targetX = worldX;
-	        targetY = worldY;
-	        // Bật chế độ tự đi tới điểm đích
-	        moving = true;
+                targetX = worldX;
+                targetY = worldY;
+                gp.getPlayer().clearPath();
+                // Bật chế độ tự đi tới điểm đích
+                moving = true;
 	    }
 	}
 	@Override

--- a/src/game/pathfinding/Node.java
+++ b/src/game/pathfinding/Node.java
@@ -1,0 +1,18 @@
+package game.pathfinding;
+
+public class Node {
+    public int col;
+    public int row;
+    public int gCost;
+    public int hCost;
+    public int fCost;
+    public boolean open;
+    public boolean checked;
+    public boolean solid;
+    public Node parent;
+
+    public Node(int col, int row) {
+        this.col = col;
+        this.row = row;
+    }
+}

--- a/src/game/pathfinding/PathFinder.java
+++ b/src/game/pathfinding/PathFinder.java
@@ -1,0 +1,137 @@
+package game.pathfinding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import game.main.GamePanel;
+
+public class PathFinder {
+    private final GamePanel gp;
+    private final Node[][] nodes;
+    private final List<Node> openList = new ArrayList<>();
+    private final List<Node> pathList = new ArrayList<>();
+    private Node startNode;
+    private Node goalNode;
+    private Node currentNode;
+    private boolean goalReached;
+    private int step;
+
+    public PathFinder(GamePanel gp) {
+        this.gp = gp;
+        nodes = new Node[gp.getMaxWorldCol()][gp.getMaxWorldRow()];
+        for (int col = 0; col < gp.getMaxWorldCol(); col++) {
+            for (int row = 0; row < gp.getMaxWorldRow(); row++) {
+                nodes[col][row] = new Node(col, row);
+            }
+        }
+    }
+
+    private void resetNodes() {
+        for (int col = 0; col < gp.getMaxWorldCol(); col++) {
+            for (int row = 0; row < gp.getMaxWorldRow(); row++) {
+                Node node = nodes[col][row];
+                node.open = false;
+                node.checked = false;
+                node.solid = false;
+                node.parent = null;
+                node.gCost = 0;
+                node.hCost = 0;
+                node.fCost = 0;
+            }
+        }
+        openList.clear();
+        pathList.clear();
+        goalReached = false;
+        step = 0;
+    }
+
+    public void setNodes(int startCol, int startRow, int goalCol, int goalRow) {
+        resetNodes();
+
+        startNode = nodes[startCol][startRow];
+        currentNode = startNode;
+        goalNode = nodes[goalCol][goalRow];
+        openList.add(currentNode);
+
+        for (int col = 0; col < gp.getMaxWorldCol(); col++) {
+            for (int row = 0; row < gp.getMaxWorldRow(); row++) {
+                int tileNum = gp.getTileManager().getMapTileNumber()[col][row];
+                if (gp.getTileManager().getTile()[tileNum].isCollision()) {
+                    nodes[col][row].solid = true;
+                }
+            }
+        }
+    }
+
+    public boolean search() {
+        while (!goalReached && step < gp.getMaxWorldCol() * gp.getMaxWorldRow()) {
+            int col = currentNode.col;
+            int row = currentNode.row;
+
+            currentNode.checked = true;
+            openList.remove(currentNode);
+
+            openNode(col, row - 1); // up
+            openNode(col - 1, row); // left
+            openNode(col, row + 1); // down
+            openNode(col + 1, row); // right
+
+            int bestNodeIndex = 0;
+            int bestNodeFCost = Integer.MAX_VALUE;
+
+            for (int i = 0; i < openList.size(); i++) {
+                Node node = openList.get(i);
+                if (node.fCost < bestNodeFCost) {
+                    bestNodeFCost = node.fCost;
+                    bestNodeIndex = i;
+                } else if (node.fCost == bestNodeFCost) {
+                    if (node.gCost < openList.get(bestNodeIndex).gCost) {
+                        bestNodeIndex = i;
+                    }
+                }
+            }
+
+            if (openList.isEmpty()) {
+                break;
+            }
+
+            currentNode = openList.get(bestNodeIndex);
+
+            if (currentNode == goalNode) {
+                goalReached = true;
+                trackPath();
+            }
+
+            step++;
+        }
+        return goalReached;
+    }
+
+    private void openNode(int col, int row) {
+        if (col < 0 || row < 0 || col >= gp.getMaxWorldCol() || row >= gp.getMaxWorldRow()) {
+            return;
+        }
+        Node node = nodes[col][row];
+        if (node.open || node.checked || node.solid) {
+            return;
+        }
+        node.open = true;
+        node.parent = currentNode;
+        node.gCost = Math.abs(col - startNode.col) + Math.abs(row - startNode.row);
+        node.hCost = Math.abs(col - goalNode.col) + Math.abs(row - goalNode.row);
+        node.fCost = node.gCost + node.hCost;
+        openList.add(node);
+    }
+
+    private void trackPath() {
+        Node current = goalNode;
+        while (current != startNode) {
+            pathList.add(0, current);
+            current = current.parent;
+        }
+    }
+
+    public List<Node> getPathList() {
+        return pathList;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce A* pathfinding nodes and search logic
- allow player to follow paths to mouse-click targets while avoiding collision tiles
- expose mouse handler and pathfinder from game panel and reset path on new clicks

## Testing
- `javac @sources.list -d build`

------
https://chatgpt.com/codex/tasks/task_e_68a6a5dd74f0832f97cc89d30ee9b6db