### PR TITLE
Add basic cultivation, skill, item, and attack area systems

### DIFF
--- a/src/game/cultivation/Cultivation.java
+++ b/src/game/cultivation/Cultivation.java
@@ -1,0 +1,61 @@
+package game.cultivation;
+
+import game.entity.Player;
+import game.skill.Skill;
+import java.util.List;
+
+public class Cultivation {
+    private Realm realm = Realm.LUYEN_KHI;
+    private int stage = 1;
+    private double currentQi = 0;
+    private double neededQi = 1000;
+    private double breakthroughChance = 0.0;
+    private final Player player;
+    private static final int MAX_STAGE = 10;
+
+    public Cultivation(Player player) {
+        this.player = player;
+    }
+
+    public void absorbQi(double amount) {
+        currentQi += amount;
+        while (currentQi >= neededQi) {
+            currentQi -= neededQi;
+            stage++;
+            applyStageBonus();
+            neededQi *= 2;
+            if (stage > MAX_STAGE) {
+                breakthroughRealm();
+            }
+        }
+    }
+
+    private void applyStageBonus() {
+        player.setSpeed((int)Math.round(player.getSpeed() * 1.015));
+        breakthroughChance += 0.001; // 0.1%
+    }
+
+    private void breakthroughRealm() {
+        realm = realm.next();
+        stage = 1;
+        player.setSpeed((int)Math.round(player.getSpeed() * 3.0));
+        player.setSpeed((int)Math.round(player.getSpeed() * 1.002));
+    }
+
+    public boolean learnSkill(Player p, Skill skill) {
+        if (stage >= skill.getRequiredStage()) {
+            List<Skill> list = p.getSkills();
+            if (!list.contains(skill)) {
+                list.add(skill);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public Realm getRealm() { return realm; }
+    public int getStage() { return stage; }
+    public double getCurrentQi() { return currentQi; }
+    public double getNeededQi() { return neededQi; }
+    public double getBreakthroughChance() { return breakthroughChance; }
+}

--- a/src/game/cultivation/Realm.java
+++ b/src/game/cultivation/Realm.java
@@ -1,0 +1,13 @@
+package game.cultivation;
+
+public enum Realm {
+    LUYEN_KHI,
+    TRUC_CO;
+
+    public Realm next() {
+        return switch (this) {
+            case LUYEN_KHI -> TRUC_CO;
+            case TRUC_CO -> TRUC_CO;
+        };
+    }
+}

--- a/src/game/entity/Entity.java
+++ b/src/game/entity/Entity.java
@@ -22,9 +22,11 @@ public abstract class Entity implements DrawableEntity {
 	private BufferedImage up1, up2, down1, down2, left1, left2, right1, right2;
 	private String direction;
 	private int spriteCouter;
-	private int spriteNum;
-	//Khu vựa va chạm
-	private Rectangle collisionArea;
+        private int spriteNum;
+        //Khu vựa va chạm
+        private Rectangle collisionArea;
+        //Khu vực sát thương
+        private Rectangle attackArea = new Rectangle(0, 0, 0, 0);
 	private boolean collisionOn = false;
 	private int collisionDefaultX, collisionDefaultY;
     private int resestTime;
@@ -154,14 +156,16 @@ public abstract class Entity implements DrawableEntity {
 	public int getScaleEntityX() { return scaleEntityX; }
 	public Entity setScaleEntityX(int scaleEntityX) { this.scaleEntityX = scaleEntityX; return this; }
 	public int getScaleEntityY() { return scaleEntityY; }
-	public Entity setScaleEntityY(int scaleEntityY) { this.scaleEntityY = scaleEntityY; return this; }
-	public String[] getDialogues() { return dialogues; } 
-	public Entity setDialogues(String[] dialogues) { this.dialogues = dialogues; return this; } 
-	public int getDialogueIndex() { return dialogueIndex; } 
-	public Entity setDialogueIndex(int dialogueIndex) { this.dialogueIndex = dialogueIndex; return this; }
-	public int getIndex() { return index; } 
-	public Entity setIndex(int index) { this.index = index; return this; }
-	public String getName() { return name; }
-	public Entity setName(String name) { this.name = name; return this; }
-	
+        public Entity setScaleEntityY(int scaleEntityY) { this.scaleEntityY = scaleEntityY; return this; }
+        public String[] getDialogues() { return dialogues; }
+        public Entity setDialogues(String[] dialogues) { this.dialogues = dialogues; return this; }
+        public int getDialogueIndex() { return dialogueIndex; }
+        public Entity setDialogueIndex(int dialogueIndex) { this.dialogueIndex = dialogueIndex; return this; }
+        public int getIndex() { return index; }
+        public Entity setIndex(int index) { this.index = index; return this; }
+        public String getName() { return name; }
+        public Entity setName(String name) { this.name = name; return this; }
+        public Rectangle getAttackArea() { return attackArea; }
+        public Entity setAttackArea(Rectangle attackArea) { this.attackArea = attackArea; return this; }
+
 }

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -8,6 +8,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
 
@@ -16,22 +17,29 @@ import game.interfaces.DrawableEntity;
 import game.main.GamePanel;
 import game.util.CameraHelper;
 import game.util.UtilityTool;
+import game.cultivation.Cultivation;
+import game.skill.Skill;
+import game.skill.FireballSkill;
 
 public class Player extends GameActor implements DrawableEntity {
 	// Vị trí nhân vật trên màn hình (luôn ở giữa)
     private final int screenX;
     private final int screenY;
     private static final int INTERACTION_RANGE = 80;
+    private final Cultivation cultivation;
+    private final List<Skill> skills = new ArrayList<>();
 
 	public Player(GamePanel gp) {
 		super(gp);
         this.screenX = gp.getScreenWidth() / 2 - (gp.getTileSize() / 2);//360
         this.screenY = gp.getScreenHeight() / 2 - (gp.getTileSize() / 2);//264
+        this.cultivation = new Cultivation(this);
         setCollision();
-		setDefaultValue();
-		getImagePlayer();
+                setDefaultValue();
+                getImagePlayer();
+        learnSkill(new FireballSkill());
 
-	}
+        }
 	public void setDefaultValue() {
 		setWorldX(100); 
 		setWorldY(100);
@@ -48,6 +56,7 @@ public class Player extends GameActor implements DrawableEntity {
         setCollisionArea(new Rectangle( 16, 32, 16, 16));
         setCollisionDefaultX(getCollisionArea().x);
         setCollisionDefaultY(getCollisionArea().y);
+        setAttackArea(new Rectangle( 16, 32, 20, 20));
     }
 	
 	public void getImagePlayer() {
@@ -157,24 +166,30 @@ public class Player extends GameActor implements DrawableEntity {
 	}
 	
 	@Override
-	public void draw(Graphics2D g2) {
-		Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
-		g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, null);
+        public void draw(Graphics2D g2) {
+                Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
+                g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, null);
         g2.setColor(Color.BLUE);
-        g2.drawRect(screenPos.x+getCollisionArea().x, screenPos.y + getCollisionArea().y, 
-        		getCollisionArea().width, getCollisionArea().height);
-	}
+        g2.drawRect(screenPos.x+getCollisionArea().x, screenPos.y + getCollisionArea().y,
+                        getCollisionArea().width, getCollisionArea().height);
+        g2.setColor(Color.ORANGE);
+        g2.drawRect(screenPos.x+getAttackArea().x, screenPos.y + getAttackArea().y,
+                        getAttackArea().width, getAttackArea().height);
+        }
 	
 	@Override
 	public void draw(Graphics2D g2, GamePanel gp) {
 		Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
-		g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, null);
-		if(gp.keyH.isDrawRect() == true) {
-	        g2.setColor(Color.BLUE);
-	        g2.drawRect(screenPos.x+getCollisionArea().x, screenPos.y + getCollisionArea().y, 
-	        		getCollisionArea().width, getCollisionArea().height);
-		}
-	}
+                g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, null);
+                if(gp.keyH.isDrawRect() == true) {
+                g2.setColor(Color.BLUE);
+                g2.drawRect(screenPos.x+getCollisionArea().x, screenPos.y + getCollisionArea().y,
+                                getCollisionArea().width, getCollisionArea().height);
+                g2.setColor(Color.ORANGE);
+                g2.drawRect(screenPos.x+getAttackArea().x, screenPos.y + getAttackArea().y,
+                                getAttackArea().width, getAttackArea().height);
+                }
+        }
 
 	private BufferedImage getDirectionImage() {
 		BufferedImage image = null;
@@ -203,16 +218,20 @@ public class Player extends GameActor implements DrawableEntity {
         BufferedImage image = null;
         try {
             image = ImageIO.read(Objects.requireNonNull(getClass().getResourceAsStream(imagePath + ".png")));
-        } 
+        }
         catch (IOException e) { e.printStackTrace(); }
         return UtilityTool.scaleImage(image, gp.getTileSize(), gp.getTileSize());
     }
 
-	public int getScreenX() { return screenX; }
-	public int getScreenY() { return screenY; }
+        public int getScreenX() { return screenX; }
+        public int getScreenY() { return screenY; }
 
-	public static int getInteractionRange() { return INTERACTION_RANGE; }
-	
+        public static int getInteractionRange() { return INTERACTION_RANGE; }
+
+        public Cultivation getCultivation() { return cultivation; }
+        public List<Skill> getSkills() { return skills; }
+        public boolean learnSkill(Skill skill) { return cultivation.learnSkill(this, skill); }
+
 }
 
 

--- a/src/game/entity/animal/cat/Cat_yellow.java
+++ b/src/game/entity/animal/cat/Cat_yellow.java
@@ -21,6 +21,7 @@ public class Cat_yellow extends Entity {
         this.setScaleEntityX(24);
         this.setScaleEntityY(24);
         this.setCollisionArea(new Rectangle( 7, 14, 10, 10));
+        this.setAttackArea(new Rectangle(7, 14, 10, 10));
         
         this.setSpriteNum(1);
         this.setSpriteCouter(0);
@@ -50,14 +51,17 @@ public class Cat_yellow extends Entity {
 
         if(UtilityTool.isInsidePlayerView(getWorldX(), getWorldY(), gp)) {
 	        
-	        g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, getScaleEntityX(), getScaleEntityY(), null);
-			if(gp.keyH.isDrawRect() == true) {
-		        g2.setColor(Color.RED);
-		        g2.drawRect(screenPos.x + getCollisionArea().x, screenPos.y + getCollisionArea().y,
-		                    getCollisionArea().width, getCollisionArea().height);
-			}
-	    }
-	}
+                g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, getScaleEntityX(), getScaleEntityY(), null);
+                        if(gp.keyH.isDrawRect() == true) {
+                        g2.setColor(Color.RED);
+                        g2.drawRect(screenPos.x + getCollisionArea().x, screenPos.y + getCollisionArea().y,
+                                    getCollisionArea().width, getCollisionArea().height);
+                        g2.setColor(Color.ORANGE);
+                        g2.drawRect(screenPos.x + getAttackArea().x, screenPos.y + getAttackArea().y,
+                                    getAttackArea().width, getAttackArea().height);
+                        }
+            }
+        }
 	
 	private BufferedImage getDirectionImage() {
 		BufferedImage image = null;

--- a/src/game/object/ObjectManager.java
+++ b/src/game/object/ObjectManager.java
@@ -6,6 +6,7 @@ import game.main.GamePanel;
 import game.object.house.OBJ_House_1;
 import game.object.tree.OBJ_Tree_1;
 import game.object.tree.OBJ_Tree_da;
+import game.object.item.OBJ_SpiritHerb;
 
 public class ObjectManager {
     private final GamePanel gp; 
@@ -33,9 +34,14 @@ public class ObjectManager {
         tree1.setScaleObjectHeight(2);	//Tỉ lệ chiều rộng * 48
         tree1.setIndex(2);
 
+        SuperObject herb = new OBJ_SpiritHerb();
+        herb.setWorldX(8 * gp.getTileSize());
+        herb.setWorldY(8 * gp.getTileSize());
+        herb.setIndex(3);
+
         gp.getObjects().add(tree1);
-//        gp.getObjects()[1] = tree;
         gp.getObjects().add(house);
+        gp.getObjects().add(herb);
     }
     
     public void setEntity(){

--- a/src/game/object/item/OBJ_SpiritHerb.java
+++ b/src/game/object/item/OBJ_SpiritHerb.java
@@ -1,0 +1,22 @@
+package game.object.item;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.Objects;
+import javax.imageio.ImageIO;
+
+import game.object.SuperObject;
+
+public class OBJ_SpiritHerb extends SuperObject {
+    public OBJ_SpiritHerb() {
+        setName("SpiritHerb");
+        try {
+            BufferedImage img = ImageIO.read(Objects.requireNonNull(getClass().getResourceAsStream("/data/tile/aa.png")));
+            setImage(img);
+            setCollision(false);
+            setCollisionArea(new Rectangle(0, 0, 48, 48));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/game/skill/FireballSkill.java
+++ b/src/game/skill/FireballSkill.java
@@ -1,0 +1,21 @@
+package game.skill;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.Objects;
+import javax.imageio.ImageIO;
+
+public class FireballSkill extends Skill {
+    private static BufferedImage loadIcon() {
+        try {
+            return ImageIO.read(Objects.requireNonNull(FireballSkill.class.getResourceAsStream("/data/tile/aaa6.png")));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public FireballSkill() {
+        super("Fireball", 1, loadIcon());
+    }
+}

--- a/src/game/skill/Skill.java
+++ b/src/game/skill/Skill.java
@@ -1,0 +1,19 @@
+package game.skill;
+
+import java.awt.image.BufferedImage;
+
+public class Skill {
+    private final String name;
+    private final int requiredStage;
+    private final BufferedImage icon;
+
+    public Skill(String name, int requiredStage, BufferedImage icon) {
+        this.name = name;
+        this.requiredStage = requiredStage;
+        this.icon = icon;
+    }
+
+    public String getName() { return name; }
+    public int getRequiredStage() { return requiredStage; }
+    public BufferedImage getIcon() { return icon; }
+}


### PR DESCRIPTION
## Summary
- add cultivation system with qi-based stage progression
- introduce skill framework and example Fireball skill
- create Spirit Herb item and spawn it in world
- render attack hitboxes for player and monsters

## Testing
- `javac -d bin @sources.list`

------
https://chatgpt.com/codex/tasks/task_e_68a6ad75f52c832f89a29fb8e2d5e4f5