### PR TITLE
Optimize map rendering and visibility checks

### DIFF
--- a/src/game/util/UtilityTool.java
+++ b/src/game/util/UtilityTool.java
@@ -3,6 +3,7 @@ package game.util;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 
+import game.entity.Player;
 import game.main.GamePanel;
 
 public class UtilityTool {
@@ -16,10 +17,17 @@ public class UtilityTool {
     
     //Objet được vẽ cách ngoài biên màn hình 2 * gp.getTileSize()
     public static boolean isInsidePlayerView(int worldX, int worldY, GamePanel gp) {
-        return worldX + 4 * gp.getTileSize() > gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() && 
-	           worldX - 4 * gp.getTileSize() < gp.getPlayer().getWorldX() + gp.getPlayer().getScreenX() &&
-	           worldY + 4 * gp.getTileSize() > gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() && 
-	           worldY - 4 * gp.getTileSize() < gp.getPlayer().getWorldY() + gp.getPlayer().getScreenY();
+        Player player = gp.getPlayer();
+        int tileSize = gp.getTileSize();
+        int offset = tileSize * 4;
+        int playerWorldX = player.getWorldX();
+        int playerWorldY = player.getWorldY();
+        int playerScreenX = player.getScreenX();
+        int playerScreenY = player.getScreenY();
+        return worldX + offset > playerWorldX - playerScreenX &&
+                   worldX - offset < playerWorldX + playerScreenX &&
+                   worldY + offset > playerWorldY - playerScreenY &&
+                   worldY - offset < playerWorldY + playerScreenY;
     }
     
     public static int getXForCenterOfText(String text, GamePanel gamePanel, Graphics2D graphics2D) {


### PR DESCRIPTION
## Summary
- Cache player and tile metrics in UtilityTool#isInsidePlayerView to avoid repeated lookups
- Simplify map loading and reuse split results for efficiency
- Cache frequently used values in TileManager.draw and streamline edge checks

## Testing
- `javac @sources.txt -d bin && echo compiled`

------
https://chatgpt.com/codex/tasks/task_e_68a6a618d73c832fab57c6ae3df51ddf