### PR TITLE
Add realm-based level system and inventory context actions

### DIFF
--- a/realms_info.txt
+++ b/realms_info.txt
@@ -1,0 +1,4 @@
+Nhục thể cảnh: 20 tiểu cảnh giới, cần đan dược khai mở đan điền để vào. Mỗi cấp tăng máu*1.2, tấn công*1.2, phòng thủ*2, các thuộc tính khác +10%. BUG: hiện tại chỉ +5%.
+Luyện khí kỳ: đột phá từ nhục thể cảnh sau 10 tiểu cảnh giới, thuộc tính nhân 2. Mỗi tiểu cảnh giới tăng giống nhục thể cảnh.
+Trúc cơ: đột phá sau luyện khí kỳ, thuộc tính nhân 3. Mỗi tiểu cảnh giới máu*1.5, tấn công*1.2, phòng thủ*1.5, các thuộc tính khác +20%.
+Các chức năng: mở đan điền, sử dụng đan tăng chỉ số, giới hạn số đan theo thể chất, hiển thị kho đồ và bảng thuộc tính khi bấm I, menu chuột phải để "Sử dụng" item.

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -13,6 +13,8 @@ import javax.imageio.ImageIO;
 
 import game.entity.inventory.Inventory;
 import game.entity.item.Item;
+import game.entity.level.LevelState;
+import game.entity.level.Physique;
 import game.interfaces.DrawableEntity;
 
 import game.main.GamePanel;
@@ -26,7 +28,12 @@ public class Player extends GameActor implements DrawableEntity {
     
     private static final int INTERACTION_RANGE = 80;
     
+    /** Túi đồ của người chơi */
     private final Inventory bag = new Inventory();
+    /** Trạng thái cấp độ của người chơi */
+    private final LevelState level = new LevelState();
+    /** Thể chất hiện tại */
+    private Physique physique = Physique.NORMAL;
 
 	public Player(GamePanel gp) {
 		super(gp);
@@ -197,7 +204,19 @@ public class Player extends GameActor implements DrawableEntity {
 	public int getScreenY() { return screenY; }
 
 	public static int getInteractionRange() { return INTERACTION_RANGE; }
-	public Inventory getBag() { return bag; } 
+    public Inventory getBag() { return bag; }
+    /**
+     * @return trạng thái cấp độ của người chơi
+     */
+    public LevelState getLevel() { return level; }
+    /**
+     * @return thể chất hiện tại của người chơi
+     */
+    public Physique getPhysique() { return physique; }
+    /**
+     * Cập nhật thể chất của người chơi
+     */
+    public void setPhysique(Physique physique) { this.physique = physique; }
 }
 
 

--- a/src/game/entity/item/elixir/DantianPill.java
+++ b/src/game/entity/item/elixir/DantianPill.java
@@ -1,0 +1,47 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+import game.entity.level.Physique;
+
+/**
+ * Đan dược khai mở đan điền.
+ */
+public class DantianPill extends Item {
+    /** icon của đan dược (tái sử dụng hình có sẵn) */
+    private static BufferedImage icon;
+
+    static {
+        try {
+            icon = ImageIO.read(DantianPill.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public DantianPill(int quantity) {
+        super("Đan khai mở đan điền", "Mở đan điền và biết thể chất", quantity, 10);
+    }
+
+    @Override
+    public void use(Player p) {
+        // mặc định cho thể chất bình thường
+        p.setPhysique(Physique.NORMAL);
+        p.getLevel().openDantian(p);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new DantianPill(qty);
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/entity/item/elixir/StatBoostPill.java
+++ b/src/game/entity/item/elixir/StatBoostPill.java
@@ -1,0 +1,54 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+import game.entity.level.LevelState;
+import game.enums.Attr;
+
+/**
+ * Đan dược tăng vĩnh viễn một chỉ số.
+ */
+public class StatBoostPill extends Item {
+    /** Thuộc tính được tăng */
+    private final Attr attr;
+    /** Lượng tăng */
+    private final int amount;
+    /** Hình ảnh icon sử dụng lại từ tài nguyên có sẵn */
+    private static BufferedImage icon;
+
+    static {
+        try {
+            icon = ImageIO.read(StatBoostPill.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public StatBoostPill(Attr attr, int amount, int quantity) {
+        super("Đan tăng " + attr.displayerName(), "Tăng vĩnh viễn " + attr.displayerName(), quantity, 99);
+        this.attr = attr;
+        this.amount = amount;
+    }
+
+    @Override
+    public void use(Player p) {
+        LevelState lvl = p.getLevel();
+        if (!lvl.consumePill(p)) return; // vượt giới hạn thì không dùng được
+        p.atts().add(attr, amount);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new StatBoostPill(attr, amount, qty);
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/entity/level/LevelState.java
+++ b/src/game/entity/level/LevelState.java
@@ -1,0 +1,80 @@
+package game.entity.level;
+
+import game.entity.Player;
+import game.entity.attributes.Attributes;
+import game.enums.Attr;
+
+/**
+ * Quản lý cấp độ của nhân vật theo đại cảnh giới và tiểu cảnh giới.
+ * Thiết kế mở rộng để thêm các cảnh giới mới trong tương lai.
+ */
+public class LevelState {
+    /** Đại cảnh giới hiện tại */
+    private MajorRealm realm;
+    /** Tiểu cảnh giới hiện tại (1-20, 0 nghĩa là chưa vào cảnh giới) */
+    private int subLevel;
+    /** Mana cần thiết của lần lên cấp trước (bug cố ý trừ sai) */
+    private int lastManaCost;
+    /** Số viên đan tăng chỉ số đã dùng trong đại cảnh giới hiện tại */
+    private int usedPill;
+
+    /**
+     * Mở đan điền để bước vào nhục thể cảnh.
+     */
+    public void openDantian(Player p) {
+        if (realm != null) return; // đã mở rồi
+        realm = MajorRealm.FLESH;
+        subLevel = 1;
+        realm.applySubLevelBonus(p.atts());
+    }
+
+    /**
+     * Lên một tiểu cảnh giới nếu đủ điều kiện.
+     * @return true nếu lên cấp thành công
+     */
+    public boolean levelUp(Player p) {
+        if (realm == null) return false;
+        int target = subLevel + 1;
+        // yêu cầu thể chất đặc biệt
+        if (target == 15 && !p.getPhysique().isVoidType()) return false;
+        if (target == 20 && !p.getPhysique().isVoidEmperor()) return false;
+        // Tính mana yêu cầu: 100 + mana lần trước (bug: trừ 10)
+        int need = 100 + lastManaCost - 10; // BUG: thiếu 10 mana
+        Attributes at = p.atts();
+        if (at.get(Attr.PEP) < need) return false;
+        subLevel = target;
+        lastManaCost = need;
+        realm.applySubLevelBonus(at);
+        if (subLevel >= 10) {
+            breakthrough(p);
+        }
+        return true;
+    }
+
+    /**
+     * Đột phá lên đại cảnh giới tiếp theo.
+     */
+    private void breakthrough(Player p) {
+        MajorRealm next = realm.next();
+        if (next == null) return;
+        realm = next;
+        subLevel = 0;
+        lastManaCost = 0;
+        usedPill = 0;
+        realm.applyBreakthrough(p.atts());
+    }
+
+    /**
+     * Kiểm tra và tăng số viên đan đã dùng.
+     * @return true nếu còn có thể dùng đan.
+     */
+    public boolean consumePill(Player p) {
+        int limit = p.getPhysique().getMaxPillPerRealm();
+        if (usedPill >= limit) return false;
+        usedPill++;
+        return true;
+    }
+
+    public MajorRealm getRealm() { return realm; }
+    public int getSubLevel() { return subLevel; }
+}

--- a/src/game/entity/level/MajorRealm.java
+++ b/src/game/entity/level/MajorRealm.java
@@ -1,0 +1,92 @@
+package game.entity.level;
+
+import game.entity.attributes.Attributes;
+import game.enums.Attr;
+
+/**
+ * Đại cảnh giới của nhân vật.
+ * Mỗi cảnh giới có hệ số cộng thuộc tính riêng.
+ */
+public enum MajorRealm {
+    /** Nhục thể cảnh */
+    FLESH {
+        @Override
+        public void applyBreakthrough(Attributes atts) {
+            // Không có nhân hệ khi mới khai mở đan điền.
+        }
+
+        @Override
+        public void applySubLevelBonus(Attributes atts) {
+            // Tăng theo yêu cầu: máu *1.2, tấn công *1.2, phòng thủ *2, còn lại +10%
+            atts.set(Attr.HEALTH, (int) (atts.get(Attr.HEALTH) * 1.2));
+            atts.set(Attr.ATTACK, (int) (atts.get(Attr.ATTACK) * 1.2));
+            atts.set(Attr.DEF, (int) (atts.get(Attr.DEF) * 2));
+            // BUG: cộng nhầm 5% thay vì 10%
+            for (Attr a : Attr.values()) {
+                if (a == Attr.HEALTH || a == Attr.ATTACK || a == Attr.DEF) continue;
+                int v = atts.get(a);
+                atts.set(a, v + (int) (v * 0.05)); // BUG intentionally
+            }
+        }
+    },
+    /** Luyện khí kỳ */
+    QI_REFINING {
+        @Override
+        public void applyBreakthrough(Attributes atts) {
+            // Sau khi đột phá luyện khí kỳ, tất cả thuộc tính *2
+            for (Attr a : Attr.values()) {
+                atts.set(a, atts.get(a) * 2);
+            }
+        }
+
+        @Override
+        public void applySubLevelBonus(Attributes atts) {
+            // Giống nhục thể cảnh
+            FLESH.applySubLevelBonus(atts);
+        }
+    },
+    /** Trúc cơ */
+    FOUNDATION {
+        @Override
+        public void applyBreakthrough(Attributes atts) {
+            // Đột phá trúc cơ: tất cả *3
+            for (Attr a : Attr.values()) {
+                atts.set(a, atts.get(a) * 3);
+            }
+        }
+
+        @Override
+        public void applySubLevelBonus(Attributes atts) {
+            // máu *1.5, tấn công *1.2, phòng thủ *1.5, còn lại +20%
+            atts.set(Attr.HEALTH, (int) (atts.get(Attr.HEALTH) * 1.5));
+            atts.set(Attr.ATTACK, (int) (atts.get(Attr.ATTACK) * 1.2));
+            atts.set(Attr.DEF, (int) (atts.get(Attr.DEF) * 1.5));
+            for (Attr a : Attr.values()) {
+                if (a == Attr.HEALTH || a == Attr.ATTACK || a == Attr.DEF) continue;
+                int v = atts.get(a);
+                atts.set(a, v + (int) (v * 0.20));
+            }
+        }
+    };
+
+    /**
+     * Áp dụng nhân hệ khi đột phá sang cảnh giới này.
+     */
+    public abstract void applyBreakthrough(Attributes atts);
+
+    /**
+     * Áp dụng cộng thuộc tính khi lên một tiểu cảnh giới trong cảnh giới này.
+     */
+    public abstract void applySubLevelBonus(Attributes atts);
+
+    /**
+     * Lấy cảnh giới kế tiếp.
+     */
+    public MajorRealm next() {
+        return switch (this) {
+            case FLESH -> QI_REFINING;
+            case QI_REFINING -> FOUNDATION;
+            default -> null;
+        };
+    }
+}

--- a/src/game/entity/level/Physique.java
+++ b/src/game/entity/level/Physique.java
@@ -1,0 +1,50 @@
+package game.entity.level;
+
+/**
+ * Phân loại thể chất của nhân vật.
+ * Ảnh hưởng đến giới hạn sử dụng đan dược và điều kiện đột phá.
+ */
+public enum Physique {
+    /** Thể chất bình thường */
+    NORMAL(10),
+    /** Thể chất hấp thụ - dùng được 20 viên */
+    ABSORB(20),
+    /** Thể chất hấp thụ 1 - dùng được 30 viên */
+    ABSORB_I(30),
+    /** Thể chất hấp thụ viên mãn - dùng được 40 viên */
+    ABSORB_FULL(40),
+    /** Thể chất hư không - cần cho tiểu cảnh giới 15 */
+    VOID(10),
+    /** Thể chất hư không đại đế - cần cho tiểu cảnh giới 20 */
+    VOID_EMPEROR(10);
+
+    /**
+     * Số lượng đan tăng chỉ số tối đa có thể sử dụng trong mỗi đại cảnh giới.
+     */
+    private final int maxPillPerRealm;
+
+    Physique(int maxPillPerRealm) {
+        this.maxPillPerRealm = maxPillPerRealm;
+    }
+
+    /**
+     * @return giới hạn số viên đan tăng chỉ số có thể dùng trong mỗi đại cảnh giới.
+     */
+    public int getMaxPillPerRealm() {
+        return maxPillPerRealm;
+    }
+
+    /**
+     * Kiểm tra có phải thể chất hư không.
+     */
+    public boolean isVoidType() {
+        return this == VOID || this == VOID_EMPEROR;
+    }
+
+    /**
+     * Kiểm tra có phải thể chất hư không đại đế.
+     */
+    public boolean isVoidEmperor() {
+        return this == VOID_EMPEROR;
+    }
+}

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -43,7 +43,8 @@ public class GamePanel extends JPanel implements Runnable {
 	private Thread thread;
 	private int FPS = 60;
 	public KeyHandler keyH = new KeyHandler(this);
-	MouseHandler mounseH = new MouseHandler(this);
+        /** Xử lý chuột */
+        MouseHandler mounseH = new MouseHandler(this);
 	private final Player player = new Player(this);
 	private final TileManager tileManager = new TileManager(this);
 	private final CollisionChecker checkCollision = new CollisionChecker(this);
@@ -63,7 +64,8 @@ public class GamePanel extends JPanel implements Runnable {
 		this.setBackground(Color.white);
 		this.setDoubleBuffered(true);
 		this.addKeyListener(keyH);
-		this.addMouseListener(mounseH);
+                this.addMouseListener(mounseH);
+                this.addMouseMotionListener(mounseH);
 		this.setFocusable(true);
 	}
 	
@@ -73,8 +75,11 @@ public class GamePanel extends JPanel implements Runnable {
 		player.getBag().add(new HealthPotion(50, 1));
 		player.getBag().add(new HealthPotion(50, 1));
 		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(30, 60));
-		player.getBag().add(new HealthPotion(390, 60));
+                player.getBag().add(new HealthPotion(30, 60));
+                player.getBag().add(new HealthPotion(390, 60));
+                // Thêm đan dược mới để test
+                player.getBag().add(new game.entity.item.elixir.DantianPill(1));
+                player.getBag().add(new game.entity.item.elixir.StatBoostPill(game.enums.Attr.ATTACK, 5, 3));
 		
 		objectManager.setObject();
 		objectManager.setEntity();
@@ -172,7 +177,11 @@ public class GamePanel extends JPanel implements Runnable {
 	public int getPlayState() { return playState; }
 	public int getPauseState() { return pauseState; }
 	public int getDialogueState() { return dialogueState; }
-	public Ui getUi() { return ui; }
+    public Ui getUi() { return ui; }
+        /**
+         * @return mouse handler hiện tại
+         */
+        public MouseHandler getMouseH() { return mounseH; }
 	
 }
 

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -2,43 +2,123 @@ package game.mouseclick;
 
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
 
+import game.entity.item.Item;
 import game.main.GamePanel;
+import game.ui.ItemGridUi;
 
-public class MouseHandler implements MouseListener {
-	public int targetX, targetY;
-	public boolean moving = false;
-	GamePanel gp;
-	public MouseHandler(GamePanel gp) { this.gp = gp; }
-	@Override
-	public void mouseClicked(MouseEvent e) { }
-	@Override
-	public void mousePressed(MouseEvent e) {
-		// Right mouse pressed
-	    if (e.getButton() == MouseEvent.BUTTON3) {
-	    	//Tọa độ x,y trên màn hình
-	        int mouseX = e.getX();
-	        int mouseY = e.getY();
-	        // Chuyển từ tọa độ điểm đích từ màn hình sang tọa độ THẾ GIỚI (map)
-	        int worldX = gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() + mouseX;
-	        int worldY = gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() + mouseY;
-	        // Lưu điểm đích trong thế giới
-	        targetX = worldX;
-	        targetY = worldY;
-	        // Bật chế độ tự đi tới điểm đích
-	        moving = true;
-	    }
-	}
-	@Override
-	public void mouseReleased(MouseEvent e) { }
-	@Override
-	public void mouseEntered(MouseEvent e) { }
-	@Override
-	public void mouseExited(MouseEvent e) { }
-	public int getTargetX() { return targetX; }
-	public MouseHandler setTargetX(int targetX) { this.targetX = targetX; return this; }
-	public int getTargetY() { return targetY; }
-	public MouseHandler setTargetY(int targetY) { this.targetY = targetY; return this; } 
-	public boolean isMoving() { return moving; } 
-	public MouseHandler setMoving(boolean moving) { this.moving = moving; return this; } 
+/**
+ * Xử lý thao tác chuột cho cả việc di chuyển và tương tác kho đồ.
+ */
+public class MouseHandler implements MouseListener, MouseMotionListener {
+    /** Tọa độ đích khi click phải để di chuyển */
+    public int targetX, targetY;
+    /** Trạng thái tự động di chuyển */
+    public boolean moving = false;
+    /** Panel game */
+    GamePanel gp;
+    /** Tọa độ chuột hiện tại */
+    private int mouseX, mouseY;
+    /** Hiển thị menu ngữ cảnh trong kho đồ */
+    private boolean showContext;
+    /** Vị trí vẽ menu ngữ cảnh */
+    private int contextX, contextY;
+    /** Item đang chọn trong menu ngữ cảnh */
+    private Item contextItem;
+
+    public MouseHandler(GamePanel gp) { this.gp = gp; }
+
+    @Override
+    public void mouseClicked(MouseEvent e) { }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+        mouseX = e.getX();
+        mouseY = e.getY();
+        // Nếu đang mở kho đồ
+        if (gp.keyH.isiPressed()) {
+            if (e.getButton() == MouseEvent.BUTTON3) {
+                // mở menu ngữ cảnh
+                contextItem = findItemAt(mouseX, mouseY);
+                if (contextItem != null) {
+                    showContext = true;
+                    contextX = mouseX;
+                    contextY = mouseY;
+                }
+            } else if (e.getButton() == MouseEvent.BUTTON1 && showContext) {
+                // click vào chữ "sử dụng"
+                if (mouseX >= contextX && mouseX <= contextX + 60 &&
+                    mouseY >= contextY && mouseY <= contextY + 20) {
+                    gp.getPlayer().useItem(contextItem);
+                }
+                showContext = false;
+            }
+            return;
+        }
+        // click phải di chuyển khi không mở kho đồ
+        if (e.getButton() == MouseEvent.BUTTON3) {
+            int worldX = gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() + mouseX;
+            int worldY = gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() + mouseY;
+            targetX = worldX;
+            targetY = worldY;
+            moving = true;
+        }
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) { }
+
+    @Override
+    public void mouseEntered(MouseEvent e) { }
+
+    @Override
+    public void mouseExited(MouseEvent e) { }
+
+    @Override
+    public void mouseDragged(MouseEvent e) { }
+
+    @Override
+    public void mouseMoved(MouseEvent e) {
+        mouseX = e.getX();
+        mouseY = e.getY();
+    }
+
+    /** Tìm item ở vị trí chuột trong kho đồ */
+    private Item findItemAt(int mx, int my) {
+        ItemGridUi grid = gp.getUi().getItemGrid();
+        int x = gp.getTileSize();
+        int y = gp.getTileSize() * 6;
+        int cols = grid.getCols();
+        int rows = grid.getRows();
+        int slot = grid.getSlotSize();
+        int gap = grid.getGap();
+        int pad = grid.getPadding();
+        int width = cols * slot + (cols - 1) * gap + pad * 2;
+        int height = rows * slot + (rows - 1) * gap + pad * 2;
+        if (mx < x || mx > x + width || my < y || my > y + height) return null;
+        int relX = mx - x - pad;
+        int relY = my - y - pad;
+        int col = relX / (slot + gap);
+        int row = relY / (slot + gap);
+        if (col < 0 || col >= cols || row < 0 || row >= rows) return null;
+        int idx = row * cols + col;
+        var items = gp.getPlayer().getBag().all();
+        return (idx < items.size()) ? items.get(idx) : null;
+    }
+
+    public int getMouseX() { return mouseX; }
+    public int getMouseY() { return mouseY; }
+    public boolean isShowContext() { return showContext; }
+    public int getContextX() { return contextX; }
+    public int getContextY() { return contextY; }
+    public Item getContextItem() { return contextItem; }
+    public void hideContext() { showContext = false; }
+
+    public int getTargetX() { return targetX; }
+    public MouseHandler setTargetX(int targetX) { this.targetX = targetX; return this; }
+    public int getTargetY() { return targetY; }
+    public MouseHandler setTargetY(int targetY) { this.targetY = targetY; return this; }
+    public boolean isMoving() { return moving; }
+    public MouseHandler setMoving(boolean moving) { this.moving = moving; return this; }
 }

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -7,6 +7,7 @@ import java.awt.Graphics2D;
 import java.util.List;
 
 import game.entity.Entity;
+import game.entity.item.Item;
 import game.main.GamePanel;
 import game.util.UtilityTool;
 
@@ -46,17 +47,59 @@ public class Ui {
 		if(gp.getGameState() == gp.getDialogueState()) {
 			drawDialogueScreen();
 		}
-		if(gp.keyH.isiPressed() == true) {
-			drawInventory(g2);
-		}
+                if(gp.keyH.isiPressed() == true) {
+                        drawInventory(g2);
+                        characterScreen(g2);
+                }
 	}
     
     private void drawInventory(Graphics2D g2) {
-    	int x = gp.getTileSize();
-    	int y = gp.getTileSize() * 6;
-    	
-    	var items = gp.getPlayer().getBag().all();
-    	itemGrid.draw(g2, x, y, items );
+        int x = gp.getTileSize();
+        int y = gp.getTileSize() * 6;
+
+        var items = gp.getPlayer().getBag().all();
+        itemGrid.draw(g2, x, y, items );
+
+        // Tooltip khi rê chuột
+        var mh = gp.getMouseH();
+        int mx = mh.getMouseX();
+        int my = mh.getMouseY();
+        var hover = getItemAt(mx, my, x, y, items);
+        if (hover != null) {
+            int w = 200; int h = 60;
+            drawSubWindow(mx, my - h, w, h, g2);
+            g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 16f));
+            g2.drawString(hover.getName(), mx + 10, my - h + 20);
+            g2.drawString(hover.getDecription(), mx + 10, my - h + 40);
+        }
+
+        // Menu ngữ cảnh "Sử dụng"
+        if (mh.isShowContext()) {
+            int cx = mh.getContextX();
+            int cy = mh.getContextY();
+            drawSubWindow(cx, cy, 60, 20, g2);
+            g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 14f));
+            g2.drawString("Sử dụng", cx + 5, cy + 15);
+        }
+    }
+
+    /** Lấy item tại vị trí chuột trong bảng kho */
+    private Item getItemAt(int mx, int my, int x, int y, java.util.List<Item> items) {
+        int cols = itemGrid.getCols();
+        int rows = itemGrid.getRows();
+        int slot = itemGrid.getSlotSize();
+        int gap = itemGrid.getGap();
+        int pad = itemGrid.getPadding();
+        int width = cols * slot + (cols - 1) * gap + pad * 2;
+        int height = rows * slot + (rows - 1) * gap + pad * 2;
+        if (mx < x || mx > x + width || my < y || my > y + height) return null;
+        int relX = mx - x - pad;
+        int relY = my - y - pad;
+        int col = relX / (slot + gap);
+        int row = relY / (slot + gap);
+        if (col < 0 || col >= cols || row < 0 || row >= rows) return null;
+        int idx = row * cols + col;
+        return (idx < items.size()) ? items.get(idx) : null;
     }
     
     private void characterScreen(Graphics2D g2) {


### PR DESCRIPTION
## Summary
- add extensible realm/level system with physique and pills
- display inventory and character stats together with hover tooltips and right-click use
- include starter pills for testing and document realms

## Testing
- `javac $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68a8559e4fb4832fb1603abf766c4872