### PR TITLE
refactor: split rendering and window management

### DIFF
--- a/src/game/main/MainGame.java
+++ b/src/game/main/MainGame.java
@@ -1,19 +1,15 @@
 package game.main;
 
-import javax.swing.JFrame;
-
+/**
+ * Entry point of the application. It prepares the game panel, hands it to the
+ * {@link WindowManager} and starts the game loop.
+ */
 public class MainGame {
-	public static void main(String[] args) {
-		JFrame window = new JFrame("Game");
-		window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		window.setResizable(true);
-		window.setTitle("Game demo");
-		GamePanel game = new GamePanel();
-		window.add(game);
-		window.pack(); // Use the JPanel component to determine window configuration
-		window.setLocationRelativeTo(null);
-		window.setVisible(true);
-	    game.setUpGame();
-		game.startGame();
-	}
+        public static void main(String[] args) {
+                GamePanel game = new GamePanel();
+                WindowManager wm = new WindowManager("Game demo", game);
+                wm.show();
+                game.setUpGame();
+                game.startGame();
+        }
 }

--- a/src/game/main/WindowManager.java
+++ b/src/game/main/WindowManager.java
@@ -1,0 +1,36 @@
+package game.main;
+
+import javax.swing.JFrame;
+
+/**
+ * WindowManager is responsible for creating and showing the main window.
+ * It configures the {@link JFrame} and attaches the game's panel.
+ */
+public class WindowManager {
+
+    /** underlying swing window */
+    private final JFrame window;
+
+    /**
+     * Create a window manager.
+     *
+     * @param title title of the window
+     * @param panel game panel to display
+     */
+    public WindowManager(String title, GamePanel panel) {
+        window = new JFrame(title);
+        window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        window.setResizable(true);
+        window.setTitle(title);
+        window.add(panel);
+        window.pack();              // size to fit panel
+        window.setLocationRelativeTo(null);
+    }
+
+    /**
+     * Display the configured window to the user.
+     */
+    public void show() {
+        window.setVisible(true);
+    }
+}

--- a/src/game/render/Renderer.java
+++ b/src/game/render/Renderer.java
@@ -1,0 +1,73 @@
+package game.render;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import game.interfaces.DrawableEntity;
+import game.main.GamePanel;
+
+/**
+ * Renderer is responsible for drawing all visual elements of the game.
+ * It gathers drawable entities, sorts them and renders them along with
+ * UI elements. This keeps rendering code separate from game logic.
+ */
+public class Renderer {
+
+    /** reference to the game panel providing game state */
+    private final GamePanel gp;
+
+    /**
+     * Create a renderer for the specified {@link GamePanel}.
+     *
+     * @param gp game panel supplying data to render
+     */
+    public Renderer(GamePanel gp) {
+        this.gp = gp;
+    }
+
+    /**
+     * Render all game elements onto the provided graphics context.
+     *
+     * @param g2 graphics context used for drawing
+     */
+    public void render(Graphics2D g2) {
+        long drawStart = 0;
+        if (gp.keyH.isCheckDrawTime()) {
+            drawStart = System.nanoTime();
+        }
+
+        // draw tiles
+        gp.getTileManager().draw(g2);
+
+        // gather drawable entities
+        List<DrawableEntity> drawList = new ArrayList<>();
+        drawList.addAll(gp.getObjects());
+        drawList.addAll(gp.getNpcs());
+        drawList.add(gp.getPlayer());
+
+        // sort entities by their foot Y coordinate for proper layering
+        drawList.sort(Comparator.comparingInt(DrawableEntity::getFootY));
+
+        // draw each entity
+        for (DrawableEntity entity : drawList) {
+            entity.draw(g2, gp);
+        }
+
+        // draw UI
+        gp.getUi().draw(g2);
+
+        // optional draw time debug information
+        if (gp.keyH.isCheckDrawTime()) {
+            long drawEnd = System.nanoTime();
+            long passedTime = drawEnd - drawStart;
+            g2.setColor(Color.white);
+            g2.drawString("Draw Time: " + passedTime, 10, 400);
+            System.out.println("Draw Time: " + passedTime);
+        }
+
+        g2.dispose();
+    }
+}

--- a/src/game/ui/ItemGridUi.java
+++ b/src/game/ui/ItemGridUi.java
@@ -11,11 +11,16 @@ import java.util.List;
 import game.entity.item.Item;
 
 public class ItemGridUi {
-	private final int cols = 8;
-	private final int rows = 3;
-	private final int slotSize;
-	private final int gap = 6;
-	private final int padding; // Viền trong của khung lớn
+        /** number of columns in the inventory grid */
+        private final int cols = 3;
+        /** number of rows in the inventory grid */
+        private final int rows = 8;
+        /** size of each slot in pixels */
+        private final int slotSize;
+        /** gap between slots */
+        private final int gap = 6;
+        /** inner padding of the outer frame */
+        private final int padding; // Viền trong của khung lớn
 	
 	public ItemGridUi(int tileSize) {
 		this.slotSize = tileSize;
@@ -29,11 +34,11 @@ public class ItemGridUi {
 //Dùng int idx = r * cols + c; và so sánh với size trước khi get.
 //inventory.all() trả về danh sách immutable (OK), nhưng vẫn phải kiểm tra chỉ số.
 //Thử thay đoạn vẽ theo code trên—lỗi sẽ hết. Nếu vẫn gặp lỗi, gửi mình dòng code hiện tại của ItemGridUi.java:54 để mình chỉnh đúng chỗ nhé.
-	public Dimension getPreferredSize() {
-		int w = cols * slotSize + (cols - 1) * gap + padding * 2;
-		int h = rows * slotSize + (cols - 1) * gap + padding * 2;
-		return new Dimension(w, h);
-	}
+        public Dimension getPreferredSize() {
+                int w = cols * slotSize + (cols - 1) * gap + padding * 2;
+                int h = rows * slotSize + (rows - 1) * gap + padding * 2;
+                return new Dimension(w, h);
+        }
 	
 	public void draw(Graphics2D g2, int x, int y, List<Item> items) {
 	    final int size = (items == null) ? 0 : items.size();
@@ -71,18 +76,21 @@ public class ItemGridUi {
 	                g2.drawImage(icon, xx + pad, yy + pad, iw, ih, null);
 	            }
 
-	            // số lượng
-	            String q = String.valueOf(it.getQuantity());
-	            g2.setFont(g2.getFont().deriveFont(Font.BOLD, 14f));
-	            FontMetrics fm = g2.getFontMetrics();
-	            int tw = fm.stringWidth(q), th = fm.getAscent();
-	            g2.setColor(new Color(0,0,0,160));
-	            g2.fillRoundRect(xx + slotSize - tw - 10, yy + slotSize - th - 6, tw + 8, th + 4, 8, 8);
-	            g2.setColor(Color.WHITE);
-	            g2.drawString(q, xx + slotSize - tw - 6, yy + slotSize - 8 + th);
-	        }
-	    }
-	}
+                    // item quantity
+                    String q = String.valueOf(it.getQuantity());
+                    g2.setFont(g2.getFont().deriveFont(Font.BOLD, 14f));
+                    FontMetrics fm = g2.getFontMetrics();
+                    int tw = fm.stringWidth(q);
+                    int th = fm.getAscent();
+                    int qx = xx + slotSize - tw - 6;
+                    int qy = yy + slotSize - 6;
+                    g2.setColor(new Color(0,0,0,160));
+                    g2.fillRoundRect(qx - 2, qy - th, tw + 4, th + 4, 8, 8);
+                    g2.setColor(Color.WHITE);
+                    g2.drawString(q, qx, qy);
+                }
+            }
+        }
 
 	public int getCols() { return cols; }
 	public int getRows() { return rows; }

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -63,17 +63,21 @@ public class Ui {
             }
 	    }
 	
-	private void drawInventory(Graphics2D g2) {
+        /**
+         * Draw the inventory panel next to the character info.
+         * Inventory slots are arranged vertically.
+         */
+        private void drawInventory(Graphics2D g2) {
         // Draw character information on the left
         characterScreen(g2);
 
         // Position inventory to the right of the character panel
-        int x = gp.getTileSize() * 7;
+        int x = gp.getTileSize() * 8;
         int y = gp.getTileSize();
-	
-	    var items = gp.getPlayer().getBag().all();
-	    handleInventoryInput(items, x, y);
-	    itemGrid.draw(g2, x, y, items );
+
+            var items = gp.getPlayer().getBag().all();
+            handleInventoryInput(items, x, y);
+            itemGrid.draw(g2, x, y, items );
 	    Dimension d = itemGrid.getPreferredSize();
 	    hoverSlot = computeSlotIndex(x, y, gp.getMousePosition());
 	
@@ -189,7 +193,7 @@ public class Ui {
 	    contextVisible = true;
 	}
 
-	public boolean handleInventoryMousePress(int mx, int my, int button) {
+        public boolean handleInventoryMousePress(int mx, int my, int button) {
         int baseX = gp.getTileSize() * 8;
         int baseY = gp.getTileSize();
 	    int idx = computeSlotIndex(baseX, baseY, new Point(mx, my));


### PR DESCRIPTION
## Summary
- factor out rendering into a dedicated `Renderer`
- add `WindowManager` to configure and show the main frame
- rotate inventory UI to vertical layout and improve quantity display

## Testing
- `javac -d bin @sources.list`

------
https://chatgpt.com/codex/tasks/task_e_68a9975fe0e4832fa9b2d1f9d3227195