### PR TITLE
feat: revamp hud and inventory layout

### DIFF
--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -43,12 +43,14 @@ public class Player extends GameActor implements DrawableEntity {
 		setSpeed(4);
 		setDirection("down");
 		setSpriteCouter(0);
-		setSpriteNum(1);
-		setName("Nguyeen pro");
-		atts().set(game.enums.Attr.HEALTH, 100);
-		atts().set(game.enums.Attr.ATTACK, 5);
-		atts().set(game.enums.Attr.DEF, 4);
-	}
+                setSpriteNum(1);
+                setName("Nguyeen pro");
+                atts().set(game.enums.Attr.HEALTH, 100);
+                atts().set(game.enums.Attr.PEP, 100);
+                atts().set(game.enums.Attr.SPIRIT, 0);
+                atts().set(game.enums.Attr.ATTACK, 5);
+                atts().set(game.enums.Attr.DEF, 4);
+        }
 	
     private void setCollision() {
         setCollisionArea(new Rectangle( 16, 32, 16, 16));

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -1,16 +1,60 @@
 package game.ui;
 
 import java.awt.Color;
+import java.awt.Graphics2D;
 
+import game.entity.Player;
+import game.enums.Attr;
+import game.main.GamePanel;
+
+/**
+ * Heads-up display that renders the player's vital bars.
+ */
 public class GameHUD {
+
+    private final GamePanel gp;
+
     // COLOR
-    private static final Color PURPLE_BG = new Color(64, 40, 90, 200);
-    private static final Color PURPLE_BORDER = new Color(140, 100, 180);
-    private static final Color NAME_COLOR = Color.BLACK;
-    private static final Color REALM_COLOR = new Color(10, 170, 80);
     private static final Color HP_FILL = new Color(210, 50, 50);
     private static final Color MP_FILL = new Color(60, 120, 230);
     private static final Color EXP_FILL = new Color(250, 150, 40);
     private static final Color BAR_BACK = new Color(30, 30, 30, 180);
     private static final Color BAR_BORDER = new Color(0, 0, 0, 180);
+
+    private static final int MAX_HEALTH = 100;
+    private static final int MAX_PEP = 100;
+    private static final int MAX_SPIRIT = 100;
+
+    public GameHUD(GamePanel gp) {
+        this.gp = gp;
+    }
+
+    public void draw(Graphics2D g2) {
+        Player p = gp.getPlayer();
+        int barWidth = gp.getTileSize() * 4;
+        int barHeight = gp.getTileSize() / 3;
+        int x = gp.getTileSize();
+        int y = gp.getTileSize() / 2;
+
+        drawBar(g2, x, y, barWidth, barHeight,
+                p.atts().get(Attr.HEALTH), MAX_HEALTH, HP_FILL);
+        y += barHeight + 6;
+        drawBar(g2, x, y, barWidth, barHeight,
+                p.atts().get(Attr.PEP), MAX_PEP, MP_FILL);
+        y += barHeight + 6;
+        drawBar(g2, x, y, barWidth, barHeight,
+                p.atts().get(Attr.SPIRIT), MAX_SPIRIT, EXP_FILL);
+    }
+
+    private void drawBar(Graphics2D g2, int x, int y, int w, int h,
+                         int value, int max, Color fill) {
+        g2.setColor(BAR_BACK);
+        g2.fillRect(x, y, w, h);
+        int filled = (int) (w * Math.max(0, Math.min(value, max)) / (double) max);
+        g2.setColor(fill);
+        g2.fillRect(x, y, filled, h);
+        g2.setColor(BAR_BORDER);
+        g2.drawRect(x, y, w, h);
+    }
 }
+

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -33,22 +33,37 @@ public class InventoryUi {
     }
 
     public void draw(Graphics2D g2) {
+        int charH = gp.getTileSize() * 8;
+        Dimension d = itemGrid.getPreferredSize();
+        int gridX = gp.getTileSize() * 8; // default position with one tile gap after character panel
+        int gridY = gp.getTileSize();
+        // ensure grid within screen
+        if (gridX + d.width > gp.getScreenWidth() - gp.getTileSize() / 2) {
+            gridX = gp.getScreenWidth() - d.width - gp.getTileSize() / 2;
+        }
+
+        int outerX = gp.getTileSize() / 2;
+        int outerY = gp.getTileSize() / 2;
+        int outerW = gridX + d.width + gp.getTileSize() / 2 - outerX;
+        int outerH = Math.max(charH, d.height) + gp.getTileSize();
+        HUDUtils.drawSubWindow(g2, outerX, outerY, outerW, outerH,
+                new Color(40,40,40,180), Color.YELLOW);
+
         // Draw character panel on the left
         characterScreen(g2);
 
-        int x = gp.getTileSize() * 8; // leave one tile gap after character panel
-        int y = gp.getTileSize();
-
         var items = gp.getPlayer().getBag().all();
-        handleInventoryInput(items, x, y);
-        hoverSlot = computeSlotIndex(x, y, gp.getMousePosition());
+        handleInventoryInput(items, gridX, gridY);
+        hoverSlot = computeSlotIndex(gridX, gridY, gp.getMousePosition());
 
-        itemGrid.draw(g2, x, y, items, selectedSlot, hoverSlot);
-        Dimension d = itemGrid.getPreferredSize();
+        itemGrid.draw(g2, gridX, gridY, items, selectedSlot, hoverSlot);
 
         int infoIdx = hoverSlot >= 0 ? hoverSlot : selectedSlot;
         if (infoIdx >= 0 && infoIdx < items.size()) {
-            drawItemTooltip(g2, x + d.width + 10, y, items.get(infoIdx));
+            Point m = gp.getMousePosition();
+            int tipX = (m != null ? m.x + 15 : gridX + d.width + 10);
+            int tipY = (m != null ? m.y + 15 : gridY);
+            drawItemTooltip(g2, tipX, tipY, items.get(infoIdx));
         }
 
         drawContextMenu(g2);
@@ -155,6 +170,12 @@ public class InventoryUi {
         g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 16f));
         int width = Math.max(g2.getFontMetrics().stringWidth(line1), g2.getFontMetrics().stringWidth(line2)) + padding * 2;
         int height = 40 + padding * 2;
+        if (x + width > gp.getScreenWidth()) {
+            x = gp.getScreenWidth() - width - 10;
+        }
+        if (y + height > gp.getScreenHeight()) {
+            y = gp.getScreenHeight() - height - 10;
+        }
         HUDUtils.drawSubWindow(g2, x, y, width, height, new Color(40,40,40,200), new Color(200, 200, 200));
         g2.setColor(Color.WHITE);
         g2.drawString(line1, x + padding, y + padding + 15);
@@ -190,7 +211,11 @@ public class InventoryUi {
     }
 
     public boolean handleMousePress(int mx, int my, int button) {
-        int baseX = gp.getTileSize() * 7;
+        int baseX = gp.getTileSize() * 8;
+        Dimension d = itemGrid.getPreferredSize();
+        if (baseX + d.width > gp.getScreenWidth() - gp.getTileSize() / 2) {
+            baseX = gp.getScreenWidth() - d.width - gp.getTileSize() / 2;
+        }
         int baseY = gp.getTileSize();
         int idx = computeSlotIndex(baseX, baseY, new Point(mx, my));
         var items = gp.getPlayer().getBag().all();

--- a/src/game/ui/ItemGridUi.java
+++ b/src/game/ui/ItemGridUi.java
@@ -12,7 +12,7 @@ import java.util.List;
 import game.entity.item.Item;
 
 public class ItemGridUi {
-	private final int cols = 8;
+        private final int cols = 6;
 	private final int rows = 3;
 	private final int slotSize;
 	private final int gap = 6;
@@ -43,7 +43,7 @@ public class ItemGridUi {
 
                 // Khung lớn
                 HUDUtils.drawSubWindow(g2, x, y, d.width, d.height,
-                                new Color(40, 40, 40, 180), new Color(200, 200, 200));
+                                new Color(20, 120, 20, 180), new Color(0, 70, 0));
 
             int startX = x + padding;
             int startY = y + padding;

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -24,12 +24,14 @@ public class Ui {
     private String currentDialogue = "";
 
     private final InventoryUi inventory;
+    private final GameHUD hud;
 
     public Ui(GamePanel gp) {
         this.gp = gp;
         this.arial_40 = new Font("Arial", Font.PLAIN, 40);
         this.arial_80B = new Font("Arial", Font.BOLD, 80);
         this.inventory = new InventoryUi(gp);
+        this.hud = new GameHUD(gp);
     }
 
     public void showMessage(String text) {
@@ -52,6 +54,7 @@ public class Ui {
         if (gp.keyH.isiPressed()) {
             inventory.draw(g2);
         }
+        hud.draw(g2);
     }
 
     public boolean handleInventoryMousePress(int mx, int my, int button) {


### PR DESCRIPTION
## Summary
- add heads-up display showing health, energy and experience bars
- prevent inventory grid from overflowing screen and show item tooltips near cursor
- wrap inventory in yellow frame with green item panel

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a9aba61dfc832f908d523f7184139a