### PR TITLE
Add physical attack capability to GreenSlime monster

### DIFF
--- a/src/game/entity/monster/GreenSlime.java
+++ b/src/game/entity/monster/GreenSlime.java
@@ -16,15 +16,26 @@ import game.util.CameraHelper;
  */
 public class GreenSlime extends GameActor {
     private final Random random = new Random();
+    private final GamePanel gp;
+
+    private final Rectangle attackArea;
+    private boolean attacking = false;
+    private int attackCounter = 0;
+    private int attackCooldown = 0;
+    private static final int ATTACK_COOLDOWN = 60;
+    private static final int ATTACK_DURATION = 20;
+    private final int attackDamage = 1;
 
     public GreenSlime(GamePanel gp) {
         super(gp);
+        this.gp = gp;
         setSpeed(1);
         setDirection("down");
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
         setCollisionArea(new Rectangle(8, 16, 32, 32));
         atts().set(Attr.HEALTH, 10);
+        attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
     }
 
     @Override
@@ -33,6 +44,7 @@ public class GreenSlime extends GameActor {
         checkCollision();
         moveIfCollisionNotDetected();
         checkAndChangeSpriteAnimation();
+        handleAttack();
     }
 
     private void setAction() {
@@ -47,11 +59,77 @@ public class GreenSlime extends GameActor {
         }
     }
 
+    private void handleAttack() {
+        if (attacking) {
+            attackCounter++;
+            if (attackCounter == 1) {
+                physicalAttack();
+            }
+            if (attackCounter > ATTACK_DURATION) {
+                attacking = false;
+                attackCounter = 0;
+                attackCooldown = ATTACK_COOLDOWN;
+            }
+        } else {
+            if (attackCooldown > 0) attackCooldown--;
+            Rectangle attackRect = getAttackRectangle();
+            Rectangle playerRect = new Rectangle(
+                    gp.getPlayer().getWorldX() + gp.getPlayer().getCollisionArea().x,
+                    gp.getPlayer().getWorldY() + gp.getPlayer().getCollisionArea().y,
+                    gp.getPlayer().getCollisionArea().width,
+                    gp.getPlayer().getCollisionArea().height
+            );
+            if (attackCooldown == 0 && attackRect.intersects(playerRect)) {
+                attacking = true;
+            }
+        }
+    }
+
+    private Rectangle getAttackRectangle() {
+        int attackX = getWorldX();
+        int attackY = getWorldY();
+        switch (getDirection()) {
+            case "up":
+                attackY -= attackArea.height;
+                break;
+            case "down":
+                attackY += getScaleEntityY();
+                break;
+            case "left":
+                attackX -= attackArea.width;
+                break;
+            case "right":
+                attackX += getScaleEntityX();
+                break;
+        }
+        return new Rectangle(attackX, attackY, attackArea.width, attackArea.height);
+    }
+
+    private void physicalAttack() {
+        Rectangle attackRect = getAttackRectangle();
+        Rectangle playerRect = new Rectangle(
+                gp.getPlayer().getWorldX() + gp.getPlayer().getCollisionArea().x,
+                gp.getPlayer().getWorldY() + gp.getPlayer().getCollisionArea().y,
+                gp.getPlayer().getCollisionArea().width,
+                gp.getPlayer().getCollisionArea().height
+        );
+        if (attackRect.intersects(playerRect)) {
+            gp.getPlayer().atts().add(Attr.HEALTH, -attackDamage);
+            gp.getUi().triggerDamageEffect();
+        }
+    }
+
     @Override
     public void draw(Graphics2D g2, GamePanel gp) {
         Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
         g2.setColor(Color.GREEN);
         g2.fillOval(screenPos.x, screenPos.y, getScaleEntityX(), getScaleEntityY());
+        if (attacking) {
+            Rectangle attackRect = getAttackRectangle();
+            Point attackScreen = CameraHelper.worldToScreen(attackRect.x, attackRect.y, gp);
+            g2.setColor(Color.RED);
+            g2.drawRect(attackScreen.x, attackScreen.y, attackRect.width, attackRect.height);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add physical attack behavior to `GreenSlime`
- draw melee attack collision area with `drawRect`

## Testing
- `javac -d /tmp/classes @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a9dd7f8618832faf296d37ac00ff0e