### PR TITLE
feat: add orc monster with pathfinding and health bar

### DIFF
--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -13,6 +13,7 @@ import javax.imageio.ImageIO;
 
 import game.entity.inventory.Inventory;
 import game.entity.item.Item;
+import game.entity.monster.Monster;
 import game.interfaces.DrawableEntity;
 
 import game.main.GamePanel;
@@ -159,6 +160,9 @@ public class Player extends GameActor implements DrawableEntity {
             return new Rectangle(attackX, attackY, attackArea.width, attackArea.height);
         }
 
+        /**
+         * Performs a melee attack and damages monsters in range.
+         */
         private void physicalAttack() {
             Rectangle attackRect = getAttackRectangle();
             for (int i = 0; i < gp.getMonsters().size(); i++) {
@@ -170,10 +174,10 @@ public class Player extends GameActor implements DrawableEntity {
                         monster.getCollisionArea().width,
                         monster.getCollisionArea().height
                 );
-                if (attackRect.intersects(monsterRect) && monster instanceof GameActor m) {
+                if (attackRect.intersects(monsterRect) && monster instanceof Monster m) {
                     int damage = atts().get(game.enums.Attr.ATTACK);
-                    m.atts().add(game.enums.Attr.HEALTH, -damage);
-                    if (m.atts().get(game.enums.Attr.HEALTH) <= 0) {
+                    m.takeDamage(damage);
+                    if (m.isDead()) {
                         gp.getMonsters().remove(i);
                         i--;
                     }

--- a/src/game/entity/monster/GreenSlime.java
+++ b/src/game/entity/monster/GreenSlime.java
@@ -6,7 +6,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.Random;
 
-import game.entity.GameActor;
 import game.enums.Attr;
 import game.main.GamePanel;
 import game.util.CameraHelper;
@@ -14,27 +13,35 @@ import game.util.CameraHelper;
 /**
  * Simple wandering monster. Damages the player on contact.
  */
-public class GreenSlime extends GameActor {
+public class GreenSlime extends Monster {
+    /** Random generator for wandering movement */
     private final Random random = new Random();
+    /** Reference to game panel */
     private final GamePanel gp;
 
+    /** Rectangle representing attack area */
     private final Rectangle attackArea;
+    /** Whether slime is currently attacking */
     private boolean attacking = false;
+    /** Attack duration counter */
     private int attackCounter = 0;
+    /** Cooldown timer between attacks */
     private int attackCooldown = 0;
+    /** Cooldown duration after an attack */
     private static final int ATTACK_COOLDOWN = 60;
+    /** How long an attack animation lasts */
     private static final int ATTACK_DURATION = 20;
+    /** Damage dealt to the player */
     private final int attackDamage = 1;
 
     public GreenSlime(GamePanel gp) {
-        super(gp);
+        super(gp, 10);
         this.gp = gp;
         setSpeed(1);
         setDirection("down");
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
         setCollisionArea(new Rectangle(8, 16, 32, 32));
-        atts().set(Attr.HEALTH, 10);
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
     }
 
@@ -45,6 +52,7 @@ public class GreenSlime extends GameActor {
         moveIfCollisionNotDetected();
         checkAndChangeSpriteAnimation();
         handleAttack();
+        updateHealthBar();
     }
 
     private void setAction() {
@@ -130,6 +138,7 @@ public class GreenSlime extends GameActor {
             g2.setColor(Color.RED);
             g2.drawRect(attackScreen.x, attackScreen.y, attackRect.width, attackRect.height);
         }
+        drawHealthBar(g2);
     }
 
     @Override

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -1,0 +1,98 @@
+package game.entity.monster;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.util.Random;
+
+import game.entity.GameActor;
+import game.enums.Attr;
+import game.main.GamePanel;
+import game.object.DroppedHealthPotion;
+import game.util.CameraHelper;
+
+/**
+ * Base class for all monsters. Handles health, damage and item drops.
+ */
+public abstract class Monster extends GameActor {
+    /** Reference to main game panel used for world data */
+    protected final GamePanel gp;
+    /** Maximum health of the monster */
+    private final int maxHealth;
+    /** Flag indicating the monster is dead */
+    private boolean dead = false;
+    /** Show the health bar when true */
+    private boolean showHealthBar = false;
+    /** Counter to hide the health bar after a delay */
+    private int healthBarCounter = 0;
+    /** Duration for which the health bar is shown (frames) */
+    private static final int HEALTH_BAR_TIME = 120; // 2 seconds at 60 FPS
+    /** Random generator for item drop chances */
+    protected final Random random = new Random();
+
+    public Monster(GamePanel gp, int maxHealth) {
+        super(gp);
+        this.gp = gp;
+        this.maxHealth = maxHealth;
+        atts().set(Attr.HEALTH, maxHealth);
+    }
+
+    /**
+     * Applies damage to the monster and handles death.
+     * @param amount amount of health to subtract
+     */
+    public void takeDamage(int amount) {
+        atts().add(Attr.HEALTH, -amount);
+        showHealthBar = true;
+        healthBarCounter = HEALTH_BAR_TIME;
+        if (atts().get(Attr.HEALTH) <= 0) {
+            dead = true;
+            dropItem();
+        }
+    }
+
+    /**
+     * @return true if monster has died
+     */
+    public boolean isDead() { return dead; }
+
+    /**
+     * Updates health bar timer each frame.
+     */
+    protected void updateHealthBar() {
+        if (showHealthBar) {
+            healthBarCounter--;
+            if (healthBarCounter <= 0) {
+                showHealthBar = false;
+            }
+        }
+    }
+
+    /**
+     * Draws the health bar above the monster when visible.
+     */
+    protected void drawHealthBar(Graphics2D g2) {
+        if (!showHealthBar) return;
+        Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
+        int barWidth = getScaleEntityX();
+        int barHeight = 4;
+        double hpPercent = atts().get(Attr.HEALTH) / (double) maxHealth;
+        int healthWidth = (int) (barWidth * hpPercent);
+        g2.setColor(Color.RED);
+        g2.fillRect(screenPos.x, screenPos.y - 10, barWidth, barHeight);
+        g2.setColor(Color.GREEN);
+        g2.fillRect(screenPos.x, screenPos.y - 10, healthWidth, barHeight);
+    }
+
+    /**
+     * Called when the monster dies to possibly drop an item.
+     */
+    protected void dropItem() {
+        if (random.nextInt(100) < 30) { // 30% drop chance
+            DroppedHealthPotion potion = new DroppedHealthPotion(gp);
+            potion.setWorldX(getWorldX());
+            potion.setWorldY(getWorldY());
+            gp.getObjects().add(potion);
+        }
+    }
+}

--- a/src/game/entity/monster/Orc.java
+++ b/src/game/entity/monster/Orc.java
@@ -1,0 +1,241 @@
+package game.entity.monster;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.Queue;
+
+import javax.imageio.ImageIO;
+
+import game.enums.Attr;
+import game.main.GamePanel;
+import game.util.CameraHelper;
+import game.util.UtilityTool;
+
+/**
+ * Orc monster that chases the player and performs melee attacks.
+ */
+public class Orc extends Monster {
+    /** Detection range to start chasing the player */
+    private static final int DETECTION_RANGE = 5 * 48; // 5 tiles
+    /** Area used to check attacks */
+    private final Rectangle attackArea;
+    /** True while attack animation plays */
+    private boolean attacking = false;
+    /** Counts frames of current attack */
+    private int attackCounter = 0;
+    /** Cooldown between attacks */
+    private int attackCooldown = 0;
+    /** Frames of cooldown after an attack */
+    private static final int ATTACK_COOLDOWN = 60;
+    /** Frames an attack lasts */
+    private static final int ATTACK_DURATION = 20;
+    /** Damage dealt to the player */
+    private final int attackDamage = 2;
+
+    // Movement and attack sprites
+    private BufferedImage attackUp1, attackUp2, attackDown1, attackDown2,
+            attackLeft1, attackLeft2, attackRight1, attackRight2;
+
+    public Orc(GamePanel gp) {
+        super(gp, 20);
+        setSpeed(2);
+        setDirection("down");
+        setScaleEntityX(gp.getTileSize());
+        setScaleEntityY(gp.getTileSize());
+        setCollisionArea(new Rectangle(8, 16, 32, 32));
+        attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
+        loadImages();
+    }
+
+    /** Loads walking and attacking images */
+    private void loadImages() {
+        try {
+            setUp1(load("/data/monster/orc/orc_up_1"));
+            setUp2(load("/data/monster/orc/orc_up_2"));
+            setDown1(load("/data/monster/orc/orc_down_1"));
+            setDown2(load("/data/monster/orc/orc_down_2"));
+            setLeft1(load("/data/monster/orc/orc_left_1"));
+            setLeft2(load("/data/monster/orc/orc_left_2"));
+            setRight1(load("/data/monster/orc/orc_right_1"));
+            setRight2(load("/data/monster/orc/orc_right_2"));
+
+            attackUp1 = load("/data/monster/orc/orc_attack_up_1");
+            attackUp2 = load("/data/monster/orc/orc_attack_up_2");
+            attackDown1 = load("/data/monster/orc/orc_attack_down_1");
+            attackDown2 = load("/data/monster/orc/orc_attack_down_2");
+            attackLeft1 = load("/data/monster/orc/orc_attack_left_1");
+            attackLeft2 = load("/data/monster/orc/orc_attack_left_2");
+            attackRight1 = load("/data/monster/orc/orc_attack_right_1");
+            attackRight2 = load("/data/monster/orc/orc_attack_right_2");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private BufferedImage load(String path) throws IOException {
+        return UtilityTool.scaleImage(
+                ImageIO.read(Objects.requireNonNull(getClass().getResourceAsStream(path + ".png"))),
+                gp.getTileSize(), gp.getTileSize());
+    }
+
+    @Override
+    public void update() {
+        updateHealthBar();
+        chasePlayer();
+        handleAttack();
+    }
+
+    /** Moves towards the player using simple BFS path-finding */
+    private void chasePlayer() {
+        int dx = Math.abs(getWorldX() - gp.getPlayer().getWorldX());
+        int dy = Math.abs(getWorldY() - gp.getPlayer().getWorldY());
+        if (dx + dy > DETECTION_RANGE) return; // too far
+        String dir = findDirectionToPlayer();
+        if (dir != null) setDirection(dir);
+        checkCollision();
+        moveIfCollisionNotDetected();
+        checkAndChangeSpriteAnimation();
+    }
+
+    /** Simple BFS to find next step direction to player */
+    private String findDirectionToPlayer() {
+        int tileSize = gp.getTileSize();
+        int startCol = getWorldX() / tileSize;
+        int startRow = getWorldY() / tileSize;
+        int goalCol = gp.getPlayer().getWorldX() / tileSize;
+        int goalRow = gp.getPlayer().getWorldY() / tileSize;
+        int maxCol = gp.getMaxWorldCol();
+        int maxRow = gp.getMaxWorldRow();
+        boolean[][] visited = new boolean[maxCol][maxRow];
+        Queue<Node> q = new LinkedList<>();
+        q.add(new Node(startCol, startRow, null));
+        visited[startCol][startRow] = true;
+        Node goal = null;
+        while (!q.isEmpty()) {
+            Node n = q.poll();
+            if (n.col == goalCol && n.row == goalRow) { goal = n; break; }
+            exploreNeighbor(n.col + 1, n.row, n, visited, q);
+            exploreNeighbor(n.col - 1, n.row, n, visited, q);
+            exploreNeighbor(n.col, n.row + 1, n, visited, q);
+            exploreNeighbor(n.col, n.row - 1, n, visited, q);
+        }
+        if (goal == null) return null;
+        Node current = goal;
+        while (current.parent != null && current.parent.parent != null) {
+            current = current.parent;
+        }
+        if (current.col > startCol) return "right";
+        if (current.col < startCol) return "left";
+        if (current.row > startRow) return "down";
+        if (current.row < startRow) return "up";
+        return null;
+    }
+
+    /** Adds neighbor tile to BFS queue if it is walkable */
+    private void exploreNeighbor(int col, int row, Node parent, boolean[][] visited, Queue<Node> q) {
+        if (col < 0 || row < 0 || col >= gp.getMaxWorldCol() || row >= gp.getMaxWorldRow()) return;
+        if (visited[col][row]) return;
+        int tileNum = gp.getTileManager().getMapTileNumber()[col][row];
+        if (gp.getTileManager().getTile()[tileNum].isCollision()) return;
+        visited[col][row] = true;
+        q.add(new Node(col, row, parent));
+    }
+
+    /** Node used for BFS */
+    private static class Node {
+        final int col, row; Node parent; Node(int c,int r,Node p){col=c;row=r;parent=p;}
+    }
+
+    /** Handles attack timing and damage */
+    private void handleAttack() {
+        if (attacking) {
+            attackCounter++;
+            if (attackCounter == 1) physicalAttack();
+            if (attackCounter > ATTACK_DURATION) {
+                attacking = false;
+                attackCounter = 0;
+                attackCooldown = ATTACK_COOLDOWN;
+            }
+        } else {
+            if (attackCooldown > 0) attackCooldown--;
+            Rectangle attackRect = getAttackRectangle();
+            Rectangle playerRect = new Rectangle(
+                gp.getPlayer().getWorldX() + gp.getPlayer().getCollisionArea().x,
+                gp.getPlayer().getWorldY() + gp.getPlayer().getCollisionArea().y,
+                gp.getPlayer().getCollisionArea().width,
+                gp.getPlayer().getCollisionArea().height);
+            if (attackCooldown == 0 && attackRect.intersects(playerRect)) {
+                attacking = true;
+            }
+        }
+    }
+
+    /** Rectangle representing the area of attack based on direction */
+    private Rectangle getAttackRectangle() {
+        int attackX = getWorldX();
+        int attackY = getWorldY();
+        switch (getDirection()) {
+            case "up" -> attackY -= attackArea.height;
+            case "down" -> attackY += getScaleEntityY();
+            case "left" -> attackX -= attackArea.width;
+            case "right" -> attackX += getScaleEntityX();
+        }
+        return new Rectangle(attackX, attackY, attackArea.width, attackArea.height);
+    }
+
+    /** Applies damage to the player if within attack range */
+    private void physicalAttack() {
+        Rectangle attackRect = getAttackRectangle();
+        Rectangle playerRect = new Rectangle(
+            gp.getPlayer().getWorldX() + gp.getPlayer().getCollisionArea().x,
+            gp.getPlayer().getWorldY() + gp.getPlayer().getCollisionArea().y,
+            gp.getPlayer().getCollisionArea().width,
+            gp.getPlayer().getCollisionArea().height);
+        if (attackRect.intersects(playerRect)) {
+            gp.getPlayer().atts().add(Attr.HEALTH, -attackDamage);
+            gp.getUi().triggerDamageEffect();
+        }
+    }
+
+    @Override
+    public void draw(Graphics2D g2, GamePanel gp) {
+        Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
+        g2.drawImage(getDirectionImage(), screenPos.x, screenPos.y, null);
+        if (attacking) {
+            Rectangle attackRect = getAttackRectangle();
+            Point attackScreen = CameraHelper.worldToScreen(attackRect.x, attackRect.y, gp);
+            g2.setColor(Color.RED);
+            g2.drawRect(attackScreen.x, attackScreen.y, attackRect.width, attackRect.height);
+        }
+        drawHealthBar(g2);
+    }
+
+    /** Chooses correct sprite based on direction and state */
+    private BufferedImage getDirectionImage() {
+        if (attacking) {
+            return switch (getDirection()) {
+                case "up" -> attackCounter < ATTACK_DURATION / 2 ? attackUp1 : attackUp2;
+                case "down" -> attackCounter < ATTACK_DURATION / 2 ? attackDown1 : attackDown2;
+                case "left" -> attackCounter < ATTACK_DURATION / 2 ? attackLeft1 : attackLeft2;
+                case "right" -> attackCounter < ATTACK_DURATION / 2 ? attackRight1 : attackRight2;
+                default -> attackDown1;
+            };
+        }
+        return switch (getDirection()) {
+            case "up" -> getSpriteNum() == 1 ? getUp1() : getUp2();
+            case "down" -> getSpriteNum() == 1 ? getDown1() : getDown2();
+            case "left" -> getSpriteNum() == 1 ? getLeft1() : getLeft2();
+            case "right" -> getSpriteNum() == 1 ? getRight1() : getRight2();
+            default -> getDown1();
+        };
+    }
+
+    @Override
+    public void draw(Graphics2D g2) { }
+}

--- a/src/game/object/DroppedHealthPotion.java
+++ b/src/game/object/DroppedHealthPotion.java
@@ -1,0 +1,35 @@
+package game.object;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.util.Objects;
+
+import javax.imageio.ImageIO;
+
+import game.main.GamePanel;
+import game.util.UtilityTool;
+
+/**
+ * Simple dropped item that represents a health potion.
+ * Player can pick it up when colliding with it.
+ */
+public class DroppedHealthPotion extends SuperObject {
+    /**
+     * Creates a health potion object at tile size of the game panel.
+     */
+    public DroppedHealthPotion(GamePanel gp) {
+        setName("HealthPotion");
+        try {
+            setImage(UtilityTool.scaleImage(
+                ImageIO.read(Objects.requireNonNull(
+                    getClass().getResourceAsStream("/data/item/elixir/HealthPotion.png"))),
+                gp.getTileSize(), gp.getTileSize()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        setCollisionArea(new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize()));
+        setCollision(true);
+        setScaleObjectWidth(1);
+        setScaleObjectHeight(1);
+    }
+}

--- a/src/game/object/ObjectManager.java
+++ b/src/game/object/ObjectManager.java
@@ -2,7 +2,7 @@ package game.object;
 
 import game.entity.Entity;
 import game.entity.animal.cat.Cat_yellow;
-import game.entity.monster.GreenSlime;
+import game.entity.monster.Orc;
 import game.main.GamePanel;
 import game.object.house.OBJ_House_1;
 import game.object.tree.OBJ_Tree_1;
@@ -52,10 +52,10 @@ public class ObjectManager {
     }
     
     public void setMonsters(){
-        Entity slime = new GreenSlime(gp);
-        slime.setWorldX(10 * gp.getTileSize());
-        slime.setWorldY(10 * gp.getTileSize());
-        gp.getMonsters().add(slime);
+        Entity orc = new Orc(gp);
+        orc.setWorldX(10 * gp.getTileSize());
+        orc.setWorldY(10 * gp.getTileSize());
+        gp.getMonsters().add(orc);
     }
 }
 


### PR DESCRIPTION
## Summary
- add Monster base with health bar and loot drops
- implement Orc with directional attack sprites and simple pathfinding
- show monster health bars and enable item drops

## Testing
- `javac @sources.txt -d bin`

------
https://chatgpt.com/codex/tasks/task_e_68a9f3618620832f98d75967852b627d