### PR TITLE
Add monster spawn zones with respawn and movement limits

### DIFF
--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -41,6 +41,8 @@ public abstract class Monster extends GameActor {
     protected int maxHealth = 1;
     /** Random dùng cho di chuyển và rơi vật phẩm */
     protected final Random random = new Random();
+    /** Khu vực mà quái vật được phép di chuyển */
+    protected Rectangle movementArea;
 
     /**
      * Tạo quái vật mới.
@@ -78,6 +80,10 @@ public abstract class Monster extends GameActor {
      * @return true nếu trong phạm vi
      */
     protected boolean isPlayerInRange() {
+        if (movementArea != null &&
+            !movementArea.contains(gp.getPlayer().getWorldX(), gp.getPlayer().getWorldY())) {
+            return false;
+        }
         int dx = gp.getPlayer().getWorldX() - getWorldX();
         int dy = gp.getPlayer().getWorldY() - getWorldY();
         double distance = Math.sqrt(dx * dx + dy * dy);
@@ -278,4 +284,35 @@ public abstract class Monster extends GameActor {
      * @return thời gian thực hiện 1 đòn tấn công
      */
     protected int getAttackDuration() { return 20; }
+
+    /**
+     * Thiết lập khu vực di chuyển giới hạn.
+     *
+     * @param area hình chữ nhật đại diện khu vực
+     */
+    public void setMovementArea(Rectangle area) { this.movementArea = area; }
+
+    /**
+     * Di chuyển nhưng không vượt ra ngoài khu vực cho phép.
+     */
+    @Override
+    public void moveIfCollisionNotDetected() {
+        if (!isCollisionOn()) {
+            int nextX = getWorldX();
+            int nextY = getWorldY();
+            switch (getDirection()) {
+                case "up" -> nextY -= getSpeed();
+                case "down" -> nextY += getSpeed();
+                case "left" -> nextX -= getSpeed();
+                case "right" -> nextX += getSpeed();
+            }
+            if (movementArea == null ||
+                (movementArea.contains(nextX, nextY) &&
+                 movementArea.contains(nextX + getScaleEntityX() - 1,
+                                       nextY + getScaleEntityY() - 1))) {
+                setWorldX(nextX);
+                setWorldY(nextY);
+            }
+        }
+    }
 }

--- a/src/game/entity/monster/MonsterZone.java
+++ b/src/game/entity/monster/MonsterZone.java
@@ -21,14 +21,34 @@ public class MonsterZone {
     private final Random random = new Random();
     private int respawnCounter = 0;
 
-    public MonsterZone(GamePanel gp, Rectangle area,
+    /**
+     * Tạo một khu vực sinh quái.
+     *
+     * @param gp          tham chiếu game panel
+     * @param startCol    cột bắt đầu (tile)
+     * @param startRow    hàng bắt đầu (tile)
+     * @param endCol      cột kết thúc (tile)
+     * @param endRow      hàng kết thúc (tile)
+     * @param factory     hàm tạo quái vật
+     * @param maxMonsters số lượng quái tối đa
+     * @param respawnMin  thời gian hồi sinh (phút)
+     */
+    public MonsterZone(GamePanel gp,
+                       int startCol, int startRow,
+                       int endCol, int endRow,
                        Supplier<? extends Monster> factory,
-                       int maxMonsters, int respawnTime) {
+                       int maxMonsters,
+                       int respawnMin) {
         this.gp = gp;
-        this.area = area;
+        int tile = gp.getTileSize();
+        int x = startCol * tile;
+        int y = startRow * tile;
+        int width = Math.max(1, (endCol - startCol + 1) * tile);
+        int height = Math.max(1, (endRow - startRow + 1) * tile);
+        this.area = new Rectangle(x, y, width, height);
         this.factory = factory;
         this.maxMonsters = maxMonsters;
-        this.respawnTime = respawnTime;
+        this.respawnTime = respawnMin * 60 * 60; // 60 FPS * 60s
         for (int i = 0; i < maxMonsters; i++) {
             spawn();
         }
@@ -51,8 +71,8 @@ public class MonsterZone {
     /** Sinh một quái vật trong khu vực. */
     private void spawn() {
         Monster m = factory.get();
-        int x = area.x + random.nextInt(Math.max(1, area.width - gp.getTileSize()));
-        int y = area.y + random.nextInt(Math.max(1, area.height - gp.getTileSize()));
+        int x = area.x + random.nextInt(Math.max(1, area.width - gp.getTileSize() + 1));
+        int y = area.y + random.nextInt(Math.max(1, area.height - gp.getTileSize() + 1));
         m.setWorldX(x);
         m.setWorldY(y);
         m.setMovementArea(area);

--- a/src/game/entity/monster/MonsterZone.java
+++ b/src/game/entity/monster/MonsterZone.java
@@ -1,0 +1,62 @@
+package game.entity.monster;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import game.main.GamePanel;
+
+/**
+ * Khu vực sinh quái vật và quản lý hồi sinh.
+ */
+public class MonsterZone {
+    private final GamePanel gp;
+    private final Rectangle area;
+    private final Supplier<? extends Monster> factory;
+    private final int maxMonsters;
+    private final int respawnTime; // tính theo frame
+    private final List<Monster> monsters = new ArrayList<>();
+    private final Random random = new Random();
+    private int respawnCounter = 0;
+
+    public MonsterZone(GamePanel gp, Rectangle area,
+                       Supplier<? extends Monster> factory,
+                       int maxMonsters, int respawnTime) {
+        this.gp = gp;
+        this.area = area;
+        this.factory = factory;
+        this.maxMonsters = maxMonsters;
+        this.respawnTime = respawnTime;
+        for (int i = 0; i < maxMonsters; i++) {
+            spawn();
+        }
+    }
+
+    /** Cập nhật bộ đếm và sinh quái nếu thiếu. */
+    public void update() {
+        monsters.removeIf(m -> !gp.getMonsters().contains(m));
+        if (monsters.size() < maxMonsters) {
+            respawnCounter++;
+            if (respawnCounter >= respawnTime) {
+                spawn();
+                respawnCounter = 0;
+            }
+        } else {
+            respawnCounter = 0;
+        }
+    }
+
+    /** Sinh một quái vật trong khu vực. */
+    private void spawn() {
+        Monster m = factory.get();
+        int x = area.x + random.nextInt(Math.max(1, area.width - gp.getTileSize()));
+        int y = area.y + random.nextInt(Math.max(1, area.height - gp.getTileSize()));
+        m.setWorldX(x);
+        m.setWorldY(y);
+        m.setMovementArea(area);
+        monsters.add(m);
+        gp.getMonsters().add(m);
+    }
+}

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -21,6 +21,7 @@ import game.object.ObjectManager;
 import game.object.SuperObject;
 import game.tile.TileManager;
 import game.ui.Ui;
+import game.entity.monster.MonsterZone;
 
 public class GamePanel extends JPanel implements Runnable {
 	private static final long serialVersionUID = 1L;
@@ -52,6 +53,7 @@ public class GamePanel extends JPanel implements Runnable {
     private final List<Entity> monsters = new ArrayList<>();
     private final ObjectManager objectManager = new ObjectManager(this);
     private final Ui ui = new Ui(this);
+    private final List<MonsterZone> monsterZones = new ArrayList<>();
     
     // GAME STATE
     private int gameState;
@@ -80,8 +82,9 @@ public class GamePanel extends JPanel implements Runnable {
                 objectManager.setObject();
                 objectManager.setEntity();
                 objectManager.setMonsters();
-		gameState = playState;
-	}
+                objectManager.setMonsterZones();
+                gameState = playState;
+        }
 	
 	public void startGame() { this.thread = new Thread(this); thread.start(); }
 	
@@ -115,6 +118,9 @@ public class GamePanel extends JPanel implements Runnable {
 	public void update() {
 		if(gameState == playState) {
                     player.update();
+                    for (MonsterZone zone : monsterZones) {
+                        zone.update();
+                    }
                     for (Entity npc : npcs) {
                         npc.update();
                     }
@@ -171,8 +177,9 @@ public class GamePanel extends JPanel implements Runnable {
 	public CollisionChecker getCheckCollision() { return checkCollision; }
 	public ObjectManager getObjectManager() { return objectManager; } 
 	public List<SuperObject> getObjects() { return objects; }
-        public List<Entity> getNpcs() { return npcs; }
+    public List<Entity> getNpcs() { return npcs; }
     public List<Entity> getMonsters() { return monsters; }
+    public List<MonsterZone> getMonsterZones() { return monsterZones; }
 
 	public int getGameState() { return gameState; }
 	public GamePanel setGameState(int gameState) { this.gameState = gameState; return this; }

--- a/src/game/object/ObjectManager.java
+++ b/src/game/object/ObjectManager.java
@@ -7,7 +7,6 @@ import game.entity.monster.Orc;
 import game.entity.monster.SkeletonLord;
 import game.entity.monster.MonsterZone;
 
-import java.awt.Rectangle;
 import game.main.GamePanel;
 import game.object.house.OBJ_House_1;
 import game.object.tree.OBJ_Tree_1;
@@ -66,12 +65,6 @@ public class ObjectManager {
         slime.setWorldY(10 * gp.getTileSize());
         gp.getMonsters().add(slime);
 
-        // Orc sử dụng sprite mới
-        Entity orc = new Orc(gp);
-        orc.setWorldX(12 * gp.getTileSize());
-        orc.setWorldY(12 * gp.getTileSize());
-        gp.getMonsters().add(orc);
-
         // Skeleton Lord sử dụng sprite mới
         Entity skeleton = new SkeletonLord(gp);
         skeleton.setWorldX(14 * gp.getTileSize());
@@ -83,10 +76,17 @@ public class ObjectManager {
      * Khởi tạo các khu vực sinh quái.
      */
     public void setMonsterZones() {
-        Rectangle area = new Rectangle(20 * gp.getTileSize(),
-                20 * gp.getTileSize(), 5 * gp.getTileSize(), 5 * gp.getTileSize());
-        MonsterZone zone = new MonsterZone(gp, area,
-                () -> new Orc(gp), 5, 60 * 60 * 5);
-        gp.getMonsterZones().add(zone);
+        MonsterZone zone1 = new MonsterZone(gp,
+                10, 2, 20, 10,
+                () -> new Orc(gp),
+                2,
+                1);
+        MonsterZone zone2 = new MonsterZone(gp,
+                2, 20, 10, 30,
+                () -> new Orc(gp),
+                3,
+                2);
+        gp.getMonsterZones().add(zone1);
+        gp.getMonsterZones().add(zone2);
     }
 }

--- a/src/game/object/ObjectManager.java
+++ b/src/game/object/ObjectManager.java
@@ -5,6 +5,9 @@ import game.entity.animal.cat.Cat_yellow;
 import game.entity.monster.GreenSlime;
 import game.entity.monster.Orc;
 import game.entity.monster.SkeletonLord;
+import game.entity.monster.MonsterZone;
+
+import java.awt.Rectangle;
 import game.main.GamePanel;
 import game.object.house.OBJ_House_1;
 import game.object.tree.OBJ_Tree_1;
@@ -74,5 +77,16 @@ public class ObjectManager {
         skeleton.setWorldX(14 * gp.getTileSize());
         skeleton.setWorldY(12 * gp.getTileSize());
         gp.getMonsters().add(skeleton);
+    }
+
+    /**
+     * Khởi tạo các khu vực sinh quái.
+     */
+    public void setMonsterZones() {
+        Rectangle area = new Rectangle(20 * gp.getTileSize(),
+                20 * gp.getTileSize(), 5 * gp.getTileSize(), 5 * gp.getTileSize());
+        MonsterZone zone = new MonsterZone(gp, area,
+                () -> new Orc(gp), 5, 60 * 60 * 5);
+        gp.getMonsterZones().add(zone);
     }
 }


### PR DESCRIPTION
## Summary
- introduce `MonsterZone` to spawn and respawn monsters inside defined areas
- allow monsters to move only within assigned areas and chase players only inside those zones
- integrate monster zones into game setup and update loops

## Testing
- `javac -d /tmp/out $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68aa86b644e4832faebd04cf2135a7fd