### PR TITLE
Add monster movement reversal and detection flags

### DIFF
--- a/src/game/entity/monster/MonsterZone.java
+++ b/src/game/entity/monster/MonsterZone.java
@@ -20,6 +20,8 @@ public class MonsterZone {
     private final List<Monster> monsters = new ArrayList<>();
     private final Random random = new Random();
     private int respawnCounter = 0;
+    private final boolean detectInSpawnArea;
+    private final boolean canAttackMonsters;
 
     /**
      * Tạo một khu vực sinh quái.
@@ -38,7 +40,9 @@ public class MonsterZone {
                        int endCol, int endRow,
                        Supplier<? extends Monster> factory,
                        int maxMonsters,
-                       int respawnMin) {
+                       int respawnMin,
+                       boolean detectInSpawnArea,
+                       boolean canAttackMonsters) {
         this.gp = gp;
         int tile = gp.getTileSize();
         int x = startCol * tile;
@@ -49,6 +53,8 @@ public class MonsterZone {
         this.factory = factory;
         this.maxMonsters = maxMonsters;
         this.respawnTime = respawnMin * 60 * 60; // 60 FPS * 60s
+        this.detectInSpawnArea = detectInSpawnArea;
+        this.canAttackMonsters = canAttackMonsters;
         for (int i = 0; i < maxMonsters; i++) {
             spawn();
         }
@@ -76,6 +82,8 @@ public class MonsterZone {
         m.setWorldX(x);
         m.setWorldY(y);
         m.setMovementArea(area);
+        m.setDetectInSpawnArea(detectInSpawnArea);
+        m.setCanAttackMonsters(canAttackMonsters);
         monsters.add(m);
         gp.getMonsters().add(m);
     }

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -124,12 +124,15 @@ public class GamePanel extends JPanel implements Runnable {
                     for (Entity npc : npcs) {
                         npc.update();
                     }
-                    for (Entity m : monsters) {
-                        m.update();
+                    List<Entity> monsterSnapshot = new ArrayList<>(monsters);
+                    for (Entity m : monsterSnapshot) {
+                        if (monsters.contains(m)) {
+                            m.update();
+                        }
                     }
-		}
-		if(gameState == pauseState) {}
-	}
+                }
+                if(gameState == pauseState) {}
+        }
 	
 	public void paintComponent(Graphics g) {
 		super.paintComponent(g);

--- a/src/game/object/ObjectManager.java
+++ b/src/game/object/ObjectManager.java
@@ -79,12 +79,16 @@ public class ObjectManager {
                 10, 2, 20, 10,
                 () -> new Orc(gp),
                 2,
-                1);
+                1,
+                true,
+                false);
         MonsterZone zone2 = new MonsterZone(gp,
                 2, 20, 10, 30,
                 () -> new Orc(gp),
                 3,
-                2);
+                2,
+                false,
+                true);
         gp.getMonsterZones().add(zone1);
         gp.getMonsterZones().add(zone2);
     }


### PR DESCRIPTION
## Summary
- Add configuration flags for monsters to auto-detect players in spawn areas and to attack other monsters
- Reverse monster direction when reaching movement boundaries
- Allow monster zones to configure detection/attack behavior for spawned monsters

## Testing
- `javac -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68aa919a02cc832fa8b2c0c8b4dc53b9