### PR TITLE
Use green slime sprite and add monster friendly-fire toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@
 ## Tính năng
 
 ## Cập nhật
-	
+
+## [1.0.2] - 2025-08-07
+
+### Trạng thái
+- Đã chỉnh lại giao diện kho đồ, thêm cờ bật/tắt quái vật tấn công cùng loại (phím **G**).
+
+### Sửa lỗi
+- Ẩn mô tả item khi chuột rời ô.
+- Kéo khung thông tin và kho đồ xuống dưới để không chồng lên thanh máu/mana/kinh nghiệm.
+- Sử dụng sprite **green-slim** cho quái slime.
+
+### Bug phát hiện
+- Tooltip của item tiếp tục hiển thị khi rời ô (đã sửa).
+
 ## Cách chạy
 
 1. Mở project trong Eclipse.

--- a/src/game/entity/monster/GreenSlime.java
+++ b/src/game/entity/monster/GreenSlime.java
@@ -36,6 +36,17 @@ public class GreenSlime extends GameActor {
         setCollisionArea(new Rectangle(8, 16, 32, 32));
         atts().set(Attr.HEALTH, 10);
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
+
+        // Load green slime sprites
+        setDown1(setup("/data/monster/slim/greenslime_down_1"));
+        setDown2(setup("/data/monster/slim/greenslime_down_2"));
+        // Use the same image for all directions for now
+        setUp1(getDown1());
+        setUp2(getDown2());
+        setLeft1(getDown1());
+        setLeft2(getDown2());
+        setRight1(getDown1());
+        setRight2(getDown2());
     }
 
     @Override
@@ -122,8 +133,9 @@ public class GreenSlime extends GameActor {
     @Override
     public void draw(Graphics2D g2, GamePanel gp) {
         Point screenPos = CameraHelper.worldToScreen(getWorldX(), getWorldY(), gp);
-        g2.setColor(Color.GREEN);
-        g2.fillOval(screenPos.x, screenPos.y, getScaleEntityX(), getScaleEntityY());
+        // Animate between the two slime sprites
+        var image = (getSpriteNum() == 1) ? getDown1() : getDown2();
+        g2.drawImage(image, screenPos.x, screenPos.y, null);
         if (attacking) {
             Rectangle attackRect = getAttackRectangle();
             Point attackScreen = CameraHelper.worldToScreen(attackRect.x, attackRect.y, gp);

--- a/src/game/entity/monster/MonsterZone.java
+++ b/src/game/entity/monster/MonsterZone.java
@@ -21,7 +21,7 @@ public class MonsterZone {
     private final Random random = new Random();
     private int respawnCounter = 0;
     private final boolean detectInSpawnArea;
-    private final boolean canAttackMonsters;
+    private boolean canAttackMonsters;
 
     /**
      * Tạo một khu vực sinh quái.
@@ -86,5 +86,13 @@ public class MonsterZone {
         m.setCanAttackMonsters(canAttackMonsters);
         monsters.add(m);
         gp.getMonsters().add(m);
+    }
+
+    /** Update whether monsters in this zone can attack each other. */
+    public void setCanAttackMonsters(boolean value) {
+        this.canAttackMonsters = value;
+        for (Monster m : monsters) {
+            m.setCanAttackMonsters(value);
+        }
     }
 }

--- a/src/game/keyhandler/KeyHandler.java
+++ b/src/game/keyhandler/KeyHandler.java
@@ -81,6 +81,10 @@ public class KeyHandler implements KeyListener {
                     if(drawRect == false) { drawRect = true; }
                     else { drawRect = false; }
             }
+            if(code == KeyEvent.VK_G) {
+                    // Toggle whether monsters can attack others of the same type
+                    gp.toggleMonsterFriendlyFire();
+            }
     }
 
     public GamePanel getGp() { return gp; }

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -21,6 +21,7 @@ import game.object.ObjectManager;
 import game.object.SuperObject;
 import game.tile.TileManager;
 import game.ui.Ui;
+import game.entity.monster.Monster;
 import game.entity.monster.MonsterZone;
 
 public class GamePanel extends JPanel implements Runnable {
@@ -54,6 +55,8 @@ public class GamePanel extends JPanel implements Runnable {
     private final ObjectManager objectManager = new ObjectManager(this);
     private final Ui ui = new Ui(this);
     private final List<MonsterZone> monsterZones = new ArrayList<>();
+    // Toggle allowing monsters to attack each other
+    private boolean monsterFriendlyFire = false;
     
     // GAME STATE
     private int gameState;
@@ -115,12 +118,12 @@ public class GamePanel extends JPanel implements Runnable {
 		}
 	}
 	
-	public void update() {
-		if(gameState == playState) {
-                    player.update();
-                    for (MonsterZone zone : monsterZones) {
-                        zone.update();
-                    }
+    public void update() {
+        if(gameState == playState) {
+            player.update();
+            for (MonsterZone zone : monsterZones) {
+                zone.update();
+            }
                     for (Entity npc : npcs) {
                         npc.update();
                     }
@@ -183,6 +186,22 @@ public class GamePanel extends JPanel implements Runnable {
     public List<Entity> getNpcs() { return npcs; }
     public List<Entity> getMonsters() { return monsters; }
     public List<MonsterZone> getMonsterZones() { return monsterZones; }
+
+    /**
+     * Toggle whether monsters can attack others of the same type.
+     * Updates existing monsters and zones.
+     */
+    public void toggleMonsterFriendlyFire() {
+        monsterFriendlyFire = !monsterFriendlyFire;
+        for (Entity e : monsters) {
+            if (e instanceof Monster m) {
+                m.setCanAttackMonsters(monsterFriendlyFire);
+            }
+        }
+        for (MonsterZone zone : monsterZones) {
+            zone.setCanAttackMonsters(monsterFriendlyFire);
+        }
+    }
 
 	public int getGameState() { return gameState; }
 	public GamePanel setGameState(int gameState) { this.gameState = gameState; return this; }

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -36,21 +36,21 @@ public class InventoryUi {
         int charH = gp.getTileSize() * 8;
         Dimension d = itemGrid.getPreferredSize();
         int gridX = gp.getTileSize() * 8; // default position with one tile gap after character panel
-        int gridY = gp.getTileSize();
+        int gridY = gp.getTileSize() * 2; // move below HUD bars
         // ensure grid within screen
         if (gridX + d.width > gp.getScreenWidth() - gp.getTileSize() / 2) {
             gridX = gp.getScreenWidth() - d.width - gp.getTileSize() / 2;
         }
 
         int outerX = gp.getTileSize() / 2;
-        int outerY = gp.getTileSize() / 2;
+        int outerY = gridY - gp.getTileSize() / 2; // keep margin similar to original
         int outerW = gridX + d.width + gp.getTileSize() / 2 - outerX;
         int outerH = Math.max(charH, d.height) + gp.getTileSize();
         HUDUtils.drawSubWindow(g2, outerX, outerY, outerW, outerH,
                 new Color(40,40,40,180), Color.YELLOW);
 
         // Draw character panel on the left
-        characterScreen(g2);
+        characterScreen(g2, gridY);
 
         var items = gp.getPlayer().getBag().all();
         handleInventoryInput(items, gridX, gridY);
@@ -58,7 +58,7 @@ public class InventoryUi {
 
         itemGrid.draw(g2, gridX, gridY, items, selectedSlot, hoverSlot);
 
-        int infoIdx = hoverSlot >= 0 ? hoverSlot : selectedSlot;
+        int infoIdx = hoverSlot; // hide tooltip when mouse leaves the slot
         if (infoIdx >= 0 && infoIdx < items.size()) {
             Point m = gp.getMousePosition();
             int tipX = (m != null ? m.x + 15 : gridX + d.width + 10);
@@ -182,11 +182,16 @@ public class InventoryUi {
         g2.drawString(line2, x + padding, y + padding + 35);
     }
 
-    private void characterScreen(Graphics2D g2) {
+    /**
+     * Draws the character attribute box at a given vertical offset.
+     *
+     * @param topY starting Y position of the box
+     */
+    private void characterScreen(Graphics2D g2, int topY) {
         int x = gp.getTileSize();
-        int y = gp.getTileSize();
+        int y = topY;
         int width = x * 6;
-        int height = y * 8;
+        int height = gp.getTileSize() * 8; // keep character box size constant
         drawSubWindow(x, y, width, height, g2);
         g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 24F));
         int textX = x + gp.getTileSize();
@@ -216,7 +221,7 @@ public class InventoryUi {
         if (baseX + d.width > gp.getScreenWidth() - gp.getTileSize() / 2) {
             baseX = gp.getScreenWidth() - d.width - gp.getTileSize() / 2;
         }
-        int baseY = gp.getTileSize();
+        int baseY = gp.getTileSize() * 2; // match grid position in draw()
         int idx = computeSlotIndex(baseX, baseY, new Point(mx, my));
         var items = gp.getPlayer().getBag().all();
         if (idx >= 0 && idx < itemGrid.getCols() * itemGrid.getRows()) {


### PR DESCRIPTION
## Summary
- Hide item tooltip when mouse leaves slot and move inventory/info panels below HUD
- Display slime using green-slim sprite
- Add key **G** to toggle monsters attacking same type and update docs

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab08426dec832fa2f329221e056e5e