### PR TITLE
feat: add cultivation system with physique and affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 ## Cập nhật
 
+## [1.0.4] - 2025-08-09
+
+### Thêm
+- Hệ thống **Thể chất** và **Linh căn** khi khởi tạo nhân vật.
+- Item **Đan dược tăng SPIRIT** giúp kiểm tra việc lên cấp.
+
+### Thay đổi
+- Mở rộng hệ thống cảnh giới với các tầng và quy tắc tăng chỉ số.
+
 ## [1.0.3] - 2025-08-08
 
 ### Thêm

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -1,0 +1,47 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+import game.enums.Attr;
+
+/**
+ * Đan dược tăng SPIRIT dùng để kiểm tra việc lên cấp.
+ * Sử dụng lại hình ảnh HealthPotion có sẵn.
+ */
+public class SpiritPotion extends Item {
+    private static BufferedImage icon;
+    private final int spiritAmount;
+
+    static {
+        try {
+            icon = ImageIO.read(SpiritPotion.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public SpiritPotion(int spiritAmount, int quantity) {
+        super("Đan dược tăng SPIRIT", "Tăng SPIRIT cho người chơi", quantity, 100);
+        this.spiritAmount = spiritAmount;
+    }
+
+    @Override
+    public void use(Player p) {
+        // Sử dụng tiện ích gainSpirit để tự kiểm tra lên cấp
+        p.gainSpirit(spiritAmount);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new SpiritPotion(spiritAmount, qty);
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/enums/Affinity.java
+++ b/src/game/enums/Affinity.java
@@ -1,0 +1,23 @@
+package game.enums;
+
+/**
+ * Linh căn (thuộc tính nguyên tố) của nhân vật.
+ */
+public enum Affinity {
+    HOA("Hỏa"),
+    MOC("Mộc"),
+    THUY("Thủy"),
+    KIM("Kim"),
+    THO("Thổ"),
+    LOI("Lôi");
+
+    private final String displayName;
+
+    Affinity(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -1,0 +1,35 @@
+package game.enums;
+
+/**
+ * Các loại thể chất của nhân vật.
+ * Ảnh hưởng tới số tầng tối đa của mỗi đại cảnh giới
+ * và có thể cung cấp thêm hiệu ứng đặc biệt.
+ */
+public enum Physique {
+    HU_KHONG("Hư không", 15),
+    HU_KHONG_DAI_DE("Hư không đại đế", 20),
+    THANH_THE("Thánh Thể", 10),
+    TIEN_LINH_THE("Tiên Linh Thể", 10),
+    THAN_THE("Thần Thể", 10),
+    NGU_HANH_LINH_CAN("Ngũ hành linh căn", 10),
+    BINH_THUONG("Bình thường", 10);
+
+    private final String displayName;
+    private final int maxTier;
+
+    Physique(String displayName, int maxTier) {
+        this.displayName = displayName;
+        this.maxTier = maxTier;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Số tiểu cảnh giới tối đa mỗi đại cảnh giới mà thể chất cho phép đạt được.
+     */
+    public int getMaxTier() {
+        return maxTier;
+    }
+}

--- a/src/game/enums/Realm.java
+++ b/src/game/enums/Realm.java
@@ -2,10 +2,15 @@ package game.enums;
 
 /**
  * Cảnh giới tu luyện của nhân vật.
- * Hiện tại mới chỉ có cấp "Phàm nhân" mặc định.
+ * Hiện tại hỗ trợ 3 cấp cơ bản.
  */
 public enum Realm {
-    PHAM_NHAN("Phàm nhân");
+    /** Cấp khởi đầu của người chơi. */
+    PHAM_NHAN("Phàm nhân"),
+    /** Sau khi đột phá từ phàm nhân. */
+    LUYEN_THE("Luyện thể"),
+    /** Đột phá từ luyện thể. */
+    LUYEN_KHI("Luyện khí");
 
     private final String displayName;
 


### PR DESCRIPTION
## Summary
- add Physique and Affinity enums to model special bodies and elemental roots
- extend Realm enum and implement level up logic with tiers and breakthrough rules in Player
- create SpiritPotion item to grant SPIRIT and test cultivation
- document new system in README

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab290a71e4832fa706e93586e9e2c9