### PR TITLE
Add cultivation realm, physique and spirit elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@
 
 ### Bug phát hiện
 - Tooltip của item tiếp tục hiển thị khi rời ô (đã sửa).
+
+## [1.0.4] - 2025-08-09
+
+### Thêm
+- Hệ thống **Thể chất** và **Linh căn** cho nhân vật, hiển thị tại bảng thuộc tính.
+- Thuộc tính now lưu cả giá trị hiện tại và tối đa; HUD hiển thị dạng `current/max`.
+- Item "Đan dược tinh thần" giúp tăng SPIRIT để thử nghiệm lên cấp.
+
+### Sửa lỗi
+- Máu và các chỉ số không bị reset về 100 sau khi sử dụng item.
+- Tấn công không bị giảm về 0 khi lên cấp.
 	
 ## Cách chạy
 

--- a/src/game/entity/attributes/Attributes.java
+++ b/src/game/entity/attributes/Attributes.java
@@ -5,14 +5,38 @@ import java.util.Map;
 
 import game.enums.Attr;
 
+/**
+ * Stores both current and maximum value for every attribute of an actor.
+ * <p>
+ * Previously the game only tracked a single value for each stat which caused
+ * the max values to be lost after leveling or using items.  By keeping a
+ * separate "max" map we can clamp consumable effects properly and display the
+ * current/maximum pair in the UI.
+ */
 public class Attributes {
-	private EnumMap<Attr, Integer> stats = new EnumMap<>(Attr.class);
-	public int get(Attr k) { return stats.getOrDefault(k, 0); }
-	public void set(Attr k, int v) { stats.put(k, Math.max(0, v)); }
-	public void add(Attr k, int d) { set(k, get(k) + d); }
-	
-	public EnumMap<Attr, Integer> getStarts() { return stats; }
-	public Attributes setStarts(EnumMap<Attr, Integer> starts) { this.stats = starts; return this; }
+    // current value of each attribute
+    private EnumMap<Attr, Integer> current = new EnumMap<>(Attr.class);
+    // maximum value ("base" value) of each attribute
+    private EnumMap<Attr, Integer> max = new EnumMap<>(Attr.class);
 
-	public Map<Attr, Integer>view() { return Map.copyOf(stats); }
+    /** Returns the current value of an attribute. */
+    public int get(Attr k) { return current.getOrDefault(k, 0); }
+
+    /** Returns the maximum (base) value of an attribute. */
+    public int getMax(Attr k) { return max.getOrDefault(k, 0); }
+
+    /** Sets the current value of an attribute. */
+    public void set(Attr k, int v) { current.put(k, Math.max(0, v)); }
+
+    /** Sets the maximum value of an attribute. */
+    public void setMax(Attr k, int v) { max.put(k, Math.max(0, v)); }
+
+    /** Convenience: set both current and max to the same value. */
+    public void setBoth(Attr k, int v) { set(k, v); setMax(k, v); }
+
+    /** Adds delta to current value (can be negative). */
+    public void add(Attr k, int d) { set(k, get(k) + d); }
+
+    /** Returns a read only view of the current stats map. */
+    public Map<Attr, Integer> view() { return Map.copyOf(current); }
 }

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -32,8 +32,10 @@ public class HealthPotion extends Item {
 
 	@Override
     public void use(Player p) {
+        // Restore health but do not exceed the player's maximum health.
         int current = p.atts().get(Attr.HEALTH);
-        int newHealth = Math.min(current + healthAmount, 100);
+        int max = p.atts().getMax(Attr.HEALTH);
+        int newHealth = Math.min(current + healthAmount, max);
         p.atts().set(Attr.HEALTH, newHealth);
         decreaseQuantity(1);
 }

--- a/src/game/entity/item/elixir/SpiritElixir.java
+++ b/src/game/entity/item/elixir/SpiritElixir.java
@@ -1,0 +1,52 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+
+/**
+ * Simple elixir that increases the SPIRIT (experience) of the player.
+ * Reuses the health potion icon for testing purposes.
+ */
+public class SpiritElixir extends Item {
+
+    private static BufferedImage icon;
+    private final int spiritAmount;
+
+    static {
+        try {
+            icon = ImageIO.read(SpiritElixir.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public SpiritElixir(int spiritAmount, int quantity) {
+        super("Đan dược tinh thần", "Tăng SPIRIT", quantity, 100);
+        this.spiritAmount = spiritAmount;
+    }
+
+    @Override
+    public void use(Player p) {
+        p.gainSpirit(spiritAmount);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new SpiritElixir(spiritAmount, qty);
+    }
+
+    @Override
+    public boolean isSameStack(Item other) {
+        if (!(other instanceof SpiritElixir se)) return false;
+        return this.getName().equals(other.getName()) && this.spiritAmount == se.spiritAmount;
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/enums/Affinity.java
+++ b/src/game/enums/Affinity.java
@@ -1,0 +1,23 @@
+package game.enums;
+
+/**
+ * Elements that define the player's spiritual roots.
+ */
+public enum Affinity {
+    FIRE("Hỏa"),
+    WOOD("Mộc"),
+    WATER("Thủy"),
+    METAL("Kim"),
+    EARTH("Thổ"),
+    LIGHTNING("Lôi");
+
+    private final String displayName;
+
+    Affinity(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -1,0 +1,23 @@
+package game.enums;
+
+/**
+ * Special body constitutions that modify leveling behaviour.
+ */
+public enum Physique {
+    NORMAL("Bình thường"),
+    HU_KHONG("Hư không"),
+    HU_KHONG_DAI_DE("Hư không đại đế"),
+    THANH_THE("Thánh Thể"),
+    TIEN_LINH_THE("Tiên Linh Thể"),
+    THAN_THE("Thần Thể");
+
+    private final String displayName;
+
+    Physique(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/game/enums/Realm.java
+++ b/src/game/enums/Realm.java
@@ -2,10 +2,11 @@ package game.enums;
 
 /**
  * Cảnh giới tu luyện của nhân vật.
- * Hiện tại mới chỉ có cấp "Phàm nhân" mặc định.
  */
 public enum Realm {
-    PHAM_NHAN("Phàm nhân");
+    PHAM_NHAN("Phàm nhân"),
+    LUYEN_THE("Luyện thể"),
+    LUYEN_KHI("Luyện khí");
 
     private final String displayName;
 

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -14,6 +14,7 @@ import game.check.CollisionChecker;
 import game.entity.Entity;
 import game.entity.Player;
 import game.entity.item.elixir.HealthPotion;
+import game.entity.item.elixir.SpiritElixir;
 import game.interfaces.DrawableEntity;
 import game.keyhandler.KeyHandler;
 import game.mouseclick.MouseHandler;
@@ -76,8 +77,10 @@ public class GamePanel extends JPanel implements Runnable {
 		player.getBag().add(new HealthPotion(50, 1));
 		player.getBag().add(new HealthPotion(50, 1));
 		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(30, 60));
-		player.getBag().add(new HealthPotion(390, 60));
+                player.getBag().add(new HealthPotion(30, 60));
+                player.getBag().add(new HealthPotion(390, 60));
+                // Đan dược SPIRIT để thử nghiệm lên cấp
+                player.getBag().add(new SpiritElixir(200, 5));
 		
                 objectManager.setObject();
                 objectManager.setEntity();

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -5,6 +5,7 @@ import java.awt.Graphics2D;
 
 import game.entity.Player;
 import game.enums.Attr;
+import game.enums.Realm;
 import game.main.GamePanel;
 
 public class GameHUD {
@@ -21,9 +22,7 @@ public class GameHUD {
     private static final Color EXP_FILL = new Color(250, 150, 40);
     private static final Color BAR_BACK = new Color(30, 30, 30, 180);
     private static final Color BAR_BORDER = new Color(0, 0, 0, 180);
-    private static final int MAX_HEALTH = 100;
-    private static final int MAX_PEP = 100;
-    private static final int MAX_SPIRIT = 100;
+    // các giá trị tối đa sẽ lấy trực tiếp từ Attributes nên không cần hằng số
 
     public GameHUD(GamePanel gp) {
         this.gp = gp;
@@ -37,6 +36,9 @@ public class GameHUD {
 
         // draw realm box
         String realmText = p.getRealm().getDisplayName();
+        if (p.getRealm() != Realm.PHAM_NHAN) {
+            realmText += " tầng " + p.getRealmLevel();
+        }
         int boxWidth = g2.getFontMetrics().stringWidth(realmText) + 20;
         int boxHeight = barHeight;
         HUDUtils.drawSubWindow(g2, margin, margin, boxWidth, boxHeight, BAR_BACK, BAR_BORDER);
@@ -47,13 +49,13 @@ public class GameHUD {
         int y = margin;
 
         drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.HEALTH), MAX_HEALTH, HP_FILL);
+                p.atts().get(Attr.HEALTH), p.atts().getMax(Attr.HEALTH), HP_FILL);
         y += barHeight + 6;
         drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.PEP), MAX_PEP, MP_FILL);
+                p.atts().get(Attr.PEP), p.atts().getMax(Attr.PEP), MP_FILL);
         y += barHeight + 6;
         drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.SPIRIT), MAX_SPIRIT, EXP_FILL);
+                p.atts().get(Attr.SPIRIT), p.atts().getMax(Attr.SPIRIT), EXP_FILL);
     }
 
     private void drawBar(Graphics2D g2, int x, int y, int w, int h,

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import game.entity.item.Item;
 import game.main.GamePanel;
+import game.enums.Affinity;
 
 /**
  * Handles rendering and interaction for the player's inventory.
@@ -190,18 +191,34 @@ public class InventoryUi {
     private void characterScreen(Graphics2D g2, int topY) {
         int x = gp.getTileSize();
         int y = topY;
-        int width = x * 6;
-        int height = gp.getTileSize() * 8; // keep character box size constant
+        int width = x * 7; // rộng hơn để hiển thị chỉ số lớn
+        int height = gp.getTileSize() * 9;
         drawSubWindow(x, y, width, height, g2);
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 24F));
+        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 20F));
         int textX = x + gp.getTileSize();
         int textY = y + gp.getTileSize();
 
         var attrs = gp.getPlayer().atts();
+        // hiển thị các thuộc tính chiến đấu
         for(game.enums.Attr a : game.enums.Attr.values()) {
-            g2.drawString(a.displayerName() + ": " + attrs.get(a), textX, textY);
-            textY += 30;
+            if (a == game.enums.Attr.PHYSIQUE || a == game.enums.Attr.AFFINITY) continue;
+            String line = a.displayerName() + ": ";
+            if (a == game.enums.Attr.HEALTH || a == game.enums.Attr.PEP || a == game.enums.Attr.SPIRIT) {
+                line += attrs.get(a) + "/" + attrs.getMax(a);
+            } else {
+                line += attrs.get(a);
+            }
+            g2.drawString(line, textX, textY);
+            textY += 24;
         }
+
+        // thông tin cảnh giới, thể chất và linh căn
+        var p = gp.getPlayer();
+        g2.drawString("Realm: " + p.getRealm().getDisplayName() + " " + p.getRealmLevel(), textX, textY); textY += 24;
+        g2.drawString("Physique: " + p.getPhysique().getDisplayName(), textX, textY); textY += 24;
+        String aff = p.getAffinities().isEmpty() ? "None" : p.getAffinities().stream()
+                .map(Affinity::getDisplayName).reduce((a,b) -> a+","+b).orElse("");
+        g2.drawString("Affinity: " + aff, textX, textY);
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {


### PR DESCRIPTION
## Summary
- track both current and max values for all attributes
- add physique, affinity and realm tiers with leveling logic
- show stats and realms in HUD/inventory and add spirit elixir for testing

## Testing
- `javac -cp src -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab36f14658832fa5f85a02993e0c1b