### PR TITLE
feat: add cultivation, physique and affinity systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@
 
 ### Bug phát hiện
 - Tooltip của item tiếp tục hiển thị khi rời ô (đã sửa).
+
+## [1.0.4] - 2025-08-09
+
+### Thêm
+- Hệ thống **tu luyện** gồm các cảnh giới Phàm nhân, Luyện thể, Luyện khí với cơ chế tăng tầng.
+- Thể chất (**Physique**) và linh căn (**Affinity**) được sinh ngẫu nhiên khi tạo nhân vật.
+- Item thử nghiệm **Đan dược tinh thần** để tăng SPIRIT và lên cấp.
+- Hiển thị chỉ số dạng *hiện tại/tối đa* cùng tên cảnh giới, thể chất, linh căn.
+
+### Sửa lỗi
+- Bình máu không còn giới hạn cứng ở 100.
+- Chỉ số sau khi lên cấp được lưu lại bằng file `player_stats.properties`.
 	
 ## Cách chạy
 

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -6,6 +6,12 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,6 +22,8 @@ import game.entity.item.Item;
 import game.interfaces.DrawableEntity;
 import game.entity.monster.Monster;
 import game.enums.Realm;
+import game.enums.Physique;
+import game.enums.Affinity;
 
 import game.main.GamePanel;
 import game.util.CameraHelper;
@@ -38,35 +46,62 @@ public class Player extends GameActor implements DrawableEntity {
     private static final int ATTACK_COOLDOWN = 20;
     private static final int ATTACK_DURATION = 10;
 
-    // Cảnh giới hiện tại của người chơi
+    // Cảnh giới hiện tại và tầng tu luyện
     private Realm realm = Realm.PHAM_NHAN;
+    private int realmLevel = 0;
+    // Thể chất và linh căn
+    private Physique physique = Physique.NORMAL;
+    private List<Affinity> affinities = new ArrayList<>();
+    // Giá trị tối đa của một số thuộc tính
+    private int maxHealth = 100;
+    private int maxPep = 100;
+    private int requiredSpirit = 100; // SPIRIT cần để lên cấp tiếp theo
 
-	public Player(GamePanel gp) {
-		super(gp);
+    private static final Path SAVE_PATH = Path.of("player_stats.properties");
+
+    public Player(GamePanel gp) {
+        super(gp);
         this.screenX = gp.getScreenWidth() / 2 - (gp.getTileSize() / 2);//360
         this.screenY = gp.getScreenHeight() / 2 - (gp.getTileSize() / 2);//264
         setCollision();
         setDefaultValue();
+        loadStats();
         getImagePlayer();
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
+    }
 
-        }
-	public void setDefaultValue() {
-		setWorldX(100); 
-		setWorldY(100);
-		setSpeed(4);
-		setDirection("down");
-		setSpriteCouter(0);
-                setSpriteNum(1);
-                setName("Nguyeen pro");
-                atts().set(game.enums.Attr.HEALTH, 100);
-                atts().set(game.enums.Attr.PEP, 100);
-                atts().set(game.enums.Attr.SPIRIT, 0);
-                atts().set(game.enums.Attr.ATTACK, 5);
-                atts().set(game.enums.Attr.DEF, 4);
+    /**
+     * Khởi tạo các giá trị mặc định cho nhân vật.
+     * Nếu đã có file lưu thì các giá trị sẽ được ghi đè khi {@link #loadStats()} gọi.
+     */
+    public void setDefaultValue() {
+        setWorldX(100);
+        setWorldY(100);
+        setSpeed(4);
+        setDirection("down");
+        setSpriteCouter(0);
+        setSpriteNum(1);
+        setName("Nguyeen pro");
+        // thuộc tính cơ bản
+        atts().set(game.enums.Attr.HEALTH, 100);
+        atts().set(game.enums.Attr.PEP, 100);
+        atts().set(game.enums.Attr.SPIRIT, 0);
+        atts().set(game.enums.Attr.ATTACK, 10);
+        atts().set(game.enums.Attr.DEF, 5);
+        atts().set(game.enums.Attr.SOULD, 5);
+        atts().set(game.enums.Attr.STRENGTH, 1);
+        // các giá trị tối đa tương ứng
+        maxHealth = 100;
+        maxPep = 100;
+        requiredSpirit = 100;
+        realm = Realm.PHAM_NHAN;
+        realmLevel = 0;
+        // random thể chất và linh căn
+        physique = Physique.randomPhysique();
+        affinities = Affinity.randomAffinities();
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
-        }
+    }
 	
     private void setCollision() {
         setCollisionArea(new Rectangle( 16, 32, 16, 16));
@@ -80,6 +115,171 @@ public class Player extends GameActor implements DrawableEntity {
 
     public void setRealm(Realm realm) {
         this.realm = realm;
+    }
+
+    /**
+     * @return tên hiển thị của cảnh giới kèm tầng hiện tại.
+     */
+    public String getRealmName() {
+        return realm == Realm.PHAM_NHAN ? realm.getDisplayName()
+                : realm.getDisplayName() + " tầng " + realmLevel;
+    }
+
+    public int getRealmLevel() { return realmLevel; }
+    public Physique getPhysique() { return physique; }
+    public List<Affinity> getAffinities() { return affinities; }
+    public String getAffinityDisplay() { return Affinity.joinDisplay(affinities); }
+    public int getMaxHealth() { return maxHealth; }
+    public int getMaxPep() { return maxPep; }
+    public int getRequiredSpirit() { return requiredSpirit; }
+
+    /**
+     * Tăng SPIRIT và kiểm tra lên cấp.
+     */
+    public void gainSpirit(int amount) {
+        atts().add(game.enums.Attr.SPIRIT, amount);
+        checkLevelUp();
+        saveStats();
+    }
+
+    /**
+     * Kiểm tra và thực hiện việc tăng cấp dựa trên SPIRIT hiện có.
+     */
+    private void checkLevelUp() {
+        while (atts().get(game.enums.Attr.SPIRIT) >= requiredSpirit) {
+            atts().add(game.enums.Attr.SPIRIT, -requiredSpirit);
+            levelUp();
+        }
+    }
+
+    /**
+     * Thực hiện tăng cấp theo quy tắc từng cảnh giới.
+     */
+    private void levelUp() {
+        switch (realm) {
+            case PHAM_NHAN -> {
+                realm = Realm.LUYEN_THE;
+                realmLevel = 1;
+                applyLuyenTheIncrease();
+                requiredSpirit = 1000;
+            }
+            case LUYEN_THE -> {
+                realmLevel++;
+                int maxLevel = getMaxLayerForRealm(Realm.LUYEN_THE);
+                if (realmLevel > maxLevel) {
+                    realm = Realm.LUYEN_KHI;
+                    realmLevel = 1;
+                    doubleAllStats();
+                    requiredSpirit *= 2; // chuyển cảnh giới
+                } else {
+                    applyLuyenTheIncrease();
+                    requiredSpirit *= 2;
+                }
+            }
+            case LUYEN_KHI -> {
+                realmLevel++;
+                applyLuyenKhiIncrease();
+                requiredSpirit *= 3;
+            }
+        }
+        atts().set(game.enums.Attr.HEALTH, maxHealth);
+        atts().set(game.enums.Attr.PEP, maxPep);
+    }
+
+    private int getMaxLayerForRealm(Realm r) {
+        int base = 10;
+        if (physique == Physique.HU_KHONG) base = 15;
+        if (physique == Physique.HU_KHONG_DAI_DE) base = 20;
+        return base;
+    }
+
+    /**
+     * Tăng chỉ số khi lên tầng Luyện thể.
+     */
+    private void applyLuyenTheIncrease() {
+        maxHealth = (int) (maxHealth * 1.5);
+        maxPep = (int) (maxPep * 1.5);
+        atts().set(game.enums.Attr.ATTACK, (int) (atts().get(game.enums.Attr.ATTACK) * 1.5));
+        atts().set(game.enums.Attr.DEF, (int) (atts().get(game.enums.Attr.DEF) * 3));
+    }
+
+    /**
+     * Tăng chỉ số khi lên tầng Luyện khí.
+     */
+    private void applyLuyenKhiIncrease() {
+        maxHealth *= 2;
+        atts().set(game.enums.Attr.ATTACK, atts().get(game.enums.Attr.ATTACK) * 2);
+        maxPep += requiredSpirit / 5;
+        atts().set(game.enums.Attr.DEF, (int) (atts().get(game.enums.Attr.DEF) * 1.5));
+    }
+
+    /**
+     * Khi đột phá sang cảnh giới mới, tất cả chỉ số nhân đôi.
+     */
+    private void doubleAllStats() {
+        maxHealth *= 2;
+        maxPep *= 2;
+        atts().set(game.enums.Attr.ATTACK, atts().get(game.enums.Attr.ATTACK) * 2);
+        atts().set(game.enums.Attr.DEF, atts().get(game.enums.Attr.DEF) * 2);
+        atts().set(game.enums.Attr.SOULD, atts().get(game.enums.Attr.SOULD) * 2);
+        atts().set(game.enums.Attr.STRENGTH, atts().get(game.enums.Attr.STRENGTH) * 2);
+    }
+
+    /**
+     * Lưu trạng thái nhân vật vào file.
+     */
+    public void saveStats() {
+        try (OutputStream out = Files.newOutputStream(SAVE_PATH)) {
+            java.util.Properties props = new java.util.Properties();
+            props.setProperty("realm", realm.name());
+            props.setProperty("realmLevel", Integer.toString(realmLevel));
+            props.setProperty("maxHealth", Integer.toString(maxHealth));
+            props.setProperty("maxPep", Integer.toString(maxPep));
+            props.setProperty("requiredSpirit", Integer.toString(requiredSpirit));
+            props.setProperty("attack", Integer.toString(atts().get(game.enums.Attr.ATTACK)));
+            props.setProperty("def", Integer.toString(atts().get(game.enums.Attr.DEF)));
+            props.setProperty("sould", Integer.toString(atts().get(game.enums.Attr.SOULD)));
+            props.setProperty("strength", Integer.toString(atts().get(game.enums.Attr.STRENGTH)));
+            props.setProperty("spirit", Integer.toString(atts().get(game.enums.Attr.SPIRIT)));
+            props.setProperty("physique", physique.name());
+            props.setProperty("affinities", affinities.stream().map(Enum::name).collect(java.util.stream.Collectors.joining(",")));
+            props.store(out, null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Đọc trạng thái nhân vật từ file lưu.
+     */
+    private void loadStats() {
+        if (Files.exists(SAVE_PATH)) {
+            java.util.Properties props = new java.util.Properties();
+            try (InputStream in = Files.newInputStream(SAVE_PATH)) {
+                props.load(in);
+                realm = Realm.valueOf(props.getProperty("realm", realm.name()));
+                realmLevel = Integer.parseInt(props.getProperty("realmLevel", "0"));
+                maxHealth = Integer.parseInt(props.getProperty("maxHealth", "100"));
+                maxPep = Integer.parseInt(props.getProperty("maxPep", "100"));
+                requiredSpirit = Integer.parseInt(props.getProperty("requiredSpirit", "100"));
+                atts().set(game.enums.Attr.ATTACK, Integer.parseInt(props.getProperty("attack", "10")));
+                atts().set(game.enums.Attr.DEF, Integer.parseInt(props.getProperty("def", "5")));
+                atts().set(game.enums.Attr.SOULD, Integer.parseInt(props.getProperty("sould", "5")));
+                atts().set(game.enums.Attr.STRENGTH, Integer.parseInt(props.getProperty("strength", "1")));
+                atts().set(game.enums.Attr.SPIRIT, Integer.parseInt(props.getProperty("spirit", "0")));
+                physique = Physique.valueOf(props.getProperty("physique", physique.name()));
+                String aff = props.getProperty("affinities", "");
+                if (!aff.isEmpty()) {
+                    affinities = Arrays.stream(aff.split(",")).map(Affinity::valueOf).collect(java.util.stream.Collectors.toList());
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            saveStats();
+        }
+        atts().set(game.enums.Attr.HEALTH, maxHealth);
+        atts().set(game.enums.Attr.PEP, maxPep);
     }
 	
 	public void getImagePlayer() {

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -33,7 +33,7 @@ public class HealthPotion extends Item {
 	@Override
     public void use(Player p) {
         int current = p.atts().get(Attr.HEALTH);
-        int newHealth = Math.min(current + healthAmount, 100);
+        int newHealth = Math.min(current + healthAmount, p.getMaxHealth());
         p.atts().set(Attr.HEALTH, newHealth);
         decreaseQuantity(1);
 }

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -1,0 +1,46 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+
+/**
+ * Đan dược giúp tăng chỉ số SPIRIT để thử nghiệm hệ thống lên cấp.
+ */
+public class SpiritPotion extends Item {
+    private static BufferedImage icon;
+    private final int spiritAmount;
+
+    static {
+        try {
+            // Tạm dùng lại hình ảnh của HealthPotion
+            icon = ImageIO.read(SpiritPotion.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.getStackTrace();
+        }
+    }
+
+    public SpiritPotion(int amount, int quantity) {
+        super("Đan dược tinh thần", "Tăng SPIRIT", quantity, 100);
+        this.spiritAmount = amount;
+    }
+
+    @Override
+    public void use(Player p) {
+        p.gainSpirit(spiritAmount);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new SpiritPotion(spiritAmount, qty);
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/enums/Affinity.java
+++ b/src/game/enums/Affinity.java
@@ -1,0 +1,72 @@
+package game.enums;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+/**
+ * Các linh căn (Affinity) của nhân vật.
+ */
+public enum Affinity {
+    FIRE("Hỏa"),
+    WOOD("Mộc"),
+    WATER("Thủy"),
+    METAL("Kim"),
+    EARTH("Thổ"),
+    THUNDER("Lôi");
+
+    private final String displayName;
+
+    Affinity(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * @return tên hiển thị của linh căn
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    private static final int[] WEIGHTS = {20,20,20,20,20,5};
+
+    /**
+     * Random danh sách linh căn theo tỉ lệ quy định.
+     * Người chơi có ít nhất 1 linh căn, 15% có 2, 10% có 3.
+     */
+    public static List<Affinity> randomAffinities() {
+        Random r = new Random();
+        int roll = r.nextInt(100);
+        int count = 1;
+        if (roll < 10) count = 3;
+        else if (roll < 25) count = 2;
+        List<Affinity> pool = new ArrayList<>(Arrays.asList(values()));
+        List<Affinity> result = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Affinity a = weightedRandom(pool, r);
+            result.add(a);
+            pool.remove(a); // không trùng lặp
+        }
+        return result;
+    }
+
+    private static Affinity weightedRandom(List<Affinity> pool, Random r) {
+        int total = pool.stream().mapToInt(a -> WEIGHTS[a.ordinal()]).sum();
+        int n = r.nextInt(total);
+        int acc = 0;
+        for (Affinity a : pool) {
+            acc += WEIGHTS[a.ordinal()];
+            if (n < acc) return a;
+        }
+        return pool.get(0);
+    }
+
+    /**
+     * Ghép nhiều linh căn thành chuỗi hiển thị.
+     */
+    public static String joinDisplay(List<Affinity> list) {
+        return list.stream().map(Affinity::getDisplayName).collect(Collectors.joining(", "));
+    }
+}

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -1,0 +1,51 @@
+package game.enums;
+
+import java.util.Random;
+
+/**
+ * Thể chất của nhân vật, quyết định một số ưu đãi khi tu luyện.
+ */
+public enum Physique {
+    /** Thể chất bình thường, không có gì nổi bật */
+    NORMAL("Thể chất bình thường"),
+    /** Cho phép tu luyện tối đa 15 tầng mỗi đại cảnh giới */
+    HU_KHONG("Hư không"),
+    /** Cho phép tu luyện tối đa 20 tầng mỗi đại cảnh giới */
+    HU_KHONG_DAI_DE("Hư không đại đế"),
+    /** Mỗi khi tăng tầng DEF tăng đặc biệt */
+    THANH_THE("Thánh Thể"),
+    /** Tốc độ tu luyện x3 */
+    TIEN_LINH_THE("Tiên Linh Thể"),
+    /** Uy lực tấn công tăng mạnh */
+    THAN_THE("Thần Thể"),
+    /** Sở hữu ngũ hành linh căn */
+    NGU_HANH_LINH_CAN("Ngũ hành linh căn");
+
+    private final String displayName;
+
+    Physique(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * @return tên hiển thị của thể chất
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Random thể chất dựa trên tỉ lệ xuất hiện.
+     * Tất cả thể chất đặc biệt có tỉ lệ 1%, còn lại là bình thường.
+     */
+    public static Physique randomPhysique() {
+        double r = new Random().nextDouble() * 100;
+        if (r < 1) return HU_KHONG;
+        if (r < 2) return HU_KHONG_DAI_DE;
+        if (r < 3) return THANH_THE;
+        if (r < 4) return TIEN_LINH_THE;
+        if (r < 5) return THAN_THE;
+        if (r < 6) return NGU_HANH_LINH_CAN;
+        return NORMAL;
+    }
+}

--- a/src/game/enums/Realm.java
+++ b/src/game/enums/Realm.java
@@ -1,11 +1,16 @@
 package game.enums;
 
 /**
- * Cảnh giới tu luyện của nhân vật.
- * Hiện tại mới chỉ có cấp "Phàm nhân" mặc định.
+ * Các đại cảnh giới tu luyện chính của nhân vật.
+ * Mỗi cảnh giới có nhiều tầng (tiểu cảnh giới).
  */
 public enum Realm {
-    PHAM_NHAN("Phàm nhân");
+    /** Trạng thái phàm nhân khởi đầu */
+    PHAM_NHAN("Phàm nhân"),
+    /** Luyện thể kỳ */
+    LUYEN_THE("Luyện thể"),
+    /** Luyện khí kỳ */
+    LUYEN_KHI("Luyện khí");
 
     private final String displayName;
 
@@ -13,6 +18,9 @@ public enum Realm {
         this.displayName = displayName;
     }
 
+    /**
+     * @return tên hiển thị của cảnh giới
+     */
     public String getDisplayName() {
         return displayName;
     }

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -14,6 +14,7 @@ import game.check.CollisionChecker;
 import game.entity.Entity;
 import game.entity.Player;
 import game.entity.item.elixir.HealthPotion;
+import game.entity.item.elixir.SpiritPotion;
 import game.interfaces.DrawableEntity;
 import game.keyhandler.KeyHandler;
 import game.mouseclick.MouseHandler;
@@ -71,13 +72,15 @@ public class GamePanel extends JPanel implements Runnable {
 	}
 	
 	public void setUpGame() { 
-		player.getBag().add(new HealthPotion(30, 50));
-		player.getBag().add(new HealthPotion(30, 60));  // 50+60 => 100 trong ô đầu + 10 sang ô mới
-		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(30, 60));
-		player.getBag().add(new HealthPotion(390, 60));
+                player.getBag().add(new HealthPotion(30, 50));
+                player.getBag().add(new HealthPotion(30, 60));  // 50+60 => 100 trong ô đầu + 10 sang ô mới
+                player.getBag().add(new HealthPotion(50, 1));
+                player.getBag().add(new HealthPotion(50, 1));
+                player.getBag().add(new HealthPotion(50, 1));
+                player.getBag().add(new HealthPotion(30, 60));
+                player.getBag().add(new HealthPotion(390, 60));
+                // Item tăng SPIRIT để thử nghiệm lên cấp
+                player.getBag().add(new SpiritPotion(200, 5));
 		
                 objectManager.setObject();
                 objectManager.setEntity();

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -19,11 +19,8 @@ public class GameHUD {
     private static final Color HP_FILL = new Color(210, 50, 50);
     private static final Color MP_FILL = new Color(60, 120, 230);
     private static final Color EXP_FILL = new Color(250, 150, 40);
-    private static final Color BAR_BACK = new Color(30, 30, 30, 180);
-    private static final Color BAR_BORDER = new Color(0, 0, 0, 180);
-    private static final int MAX_HEALTH = 100;
-    private static final int MAX_PEP = 100;
-    private static final int MAX_SPIRIT = 100;
+      private static final Color BAR_BACK = new Color(30, 30, 30, 180);
+      private static final Color BAR_BORDER = new Color(0, 0, 0, 180);
 
     public GameHUD(GamePanel gp) {
         this.gp = gp;
@@ -36,7 +33,7 @@ public class GameHUD {
         int margin = 5;
 
         // draw realm box
-        String realmText = p.getRealm().getDisplayName();
+          String realmText = p.getRealmName();
         int boxWidth = g2.getFontMetrics().stringWidth(realmText) + 20;
         int boxHeight = barHeight;
         HUDUtils.drawSubWindow(g2, margin, margin, boxWidth, boxHeight, BAR_BACK, BAR_BORDER);
@@ -46,24 +43,29 @@ public class GameHUD {
         int x = margin + boxWidth + 10;
         int y = margin;
 
-        drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.HEALTH), MAX_HEALTH, HP_FILL);
-        y += barHeight + 6;
-        drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.PEP), MAX_PEP, MP_FILL);
-        y += barHeight + 6;
-        drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.SPIRIT), MAX_SPIRIT, EXP_FILL);
-    }
+          drawBar(g2, x, y, barWidth, barHeight,
+                  p.atts().get(Attr.HEALTH), p.getMaxHealth(), HP_FILL);
+          y += barHeight + 6;
+          drawBar(g2, x, y, barWidth, barHeight,
+                  p.atts().get(Attr.PEP), p.getMaxPep(), MP_FILL);
+          y += barHeight + 6;
+          drawBar(g2, x, y, barWidth, barHeight,
+                  p.atts().get(Attr.SPIRIT), p.getRequiredSpirit(), EXP_FILL);
+      }
 
-    private void drawBar(Graphics2D g2, int x, int y, int w, int h,
-                         int value, int max, Color fill) {
-        g2.setColor(BAR_BACK);
-        g2.fillRect(x, y, w, h);
-        int filled = (int) (w * Math.max(0, Math.min(value, max)) / (double) max);
-        g2.setColor(fill);
-        g2.fillRect(x, y, filled, h);
-        g2.setColor(BAR_BORDER);
-        g2.drawRect(x, y, w, h);
-    }
+      private void drawBar(Graphics2D g2, int x, int y, int w, int h,
+                           int value, int max, Color fill) {
+          g2.setColor(BAR_BACK);
+          g2.fillRect(x, y, w, h);
+          int filled = (int) (w * Math.max(0, Math.min(value, max)) / (double) max);
+          g2.setColor(fill);
+          g2.fillRect(x, y, filled, h);
+          g2.setColor(BAR_BORDER);
+          g2.drawRect(x, y, w, h);
+          String text = value + "/" + max;
+          int tx = x + w / 2 - g2.getFontMetrics().stringWidth(text) / 2;
+          int ty = y + h - 6;
+          g2.setColor(Color.WHITE);
+          g2.drawString(text, tx, ty);
+      }
 }

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -197,11 +197,19 @@ public class InventoryUi {
         int textX = x + gp.getTileSize();
         int textY = y + gp.getTileSize();
 
-        var attrs = gp.getPlayer().atts();
-        for(game.enums.Attr a : game.enums.Attr.values()) {
-            g2.drawString(a.displayerName() + ": " + attrs.get(a), textX, textY);
-            textY += 30;
-        }
+        var p = gp.getPlayer();
+        var attrs = p.atts();
+        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 18F));
+        g2.drawString("Realm: " + p.getRealmName(), textX, textY); textY += 20;
+        g2.drawString("Physique: " + p.getPhysique().getDisplayName(), textX, textY); textY += 20;
+        g2.drawString("Affinity: " + p.getAffinityDisplay(), textX, textY); textY += 20;
+        g2.drawString("Health: " + attrs.get(game.enums.Attr.HEALTH) + "/" + p.getMaxHealth(), textX, textY); textY += 20;
+        g2.drawString("Pep: " + attrs.get(game.enums.Attr.PEP) + "/" + p.getMaxPep(), textX, textY); textY += 20;
+        g2.drawString("Spirit: " + attrs.get(game.enums.Attr.SPIRIT) + "/" + p.getRequiredSpirit(), textX, textY); textY += 20;
+        g2.drawString("Attack: " + attrs.get(game.enums.Attr.ATTACK), textX, textY); textY += 20;
+        g2.drawString("Def: " + attrs.get(game.enums.Attr.DEF), textX, textY); textY += 20;
+        g2.drawString("Sould: " + attrs.get(game.enums.Attr.SOULD), textX, textY); textY += 20;
+        g2.drawString("Strength: " + attrs.get(game.enums.Attr.STRENGTH), textX, textY);
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {


### PR DESCRIPTION
## Summary
- expand realm enum and add physique & affinity types with random generation
- implement player cultivation leveling with spirit-based stats and persistence
- show realm, physique, affinity and current/max stats in HUD and inventory; add spirit potion item

## Testing
- `javac -encoding UTF-8 -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab36ea6ad4832faab6976a4bae8ea0