### PR TITLE
feat: add cultivation and attribute systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 ## Cập nhật
 
+## [1.0.4] - 2025-08-09
+
+### Thêm
+- Hệ thống **Thể chất** và **Linh căn** khi khởi tạo nhân vật.
+- Mở rộng hệ thống **Cảnh giới** với Luyện thể/Luyện khí và tăng chỉ số khi lên cấp.
+- Item mới **Đan dược tinh thần** giúp cộng Spirit để kiểm tra lên cấp.
+- HUD và bảng thuộc tính hiển thị tên cảnh giới, thể chất và linh căn hiện tại.
+
+### Sửa lỗi
+- Sử dụng item không còn đặt lại máu về 100 mà giới hạn theo chỉ số tối đa.
+
 ## [1.0.3] - 2025-08-08
 
 ### Thêm

--- a/src/game/entity/attributes/Attributes.java
+++ b/src/game/entity/attributes/Attributes.java
@@ -5,14 +5,58 @@ import java.util.Map;
 
 import game.enums.Attr;
 
+/**
+ * Lưu trữ các thuộc tính chiến đấu của nhân vật.
+ * <p>
+ * Mỗi thuộc tính có giá trị hiện tại và giá trị tối đa (để hiển thị thanh máu, năng lượng...).
+ * Một số thuộc tính như Attack/Def có thể dùng chung giá trị max hiện tại.
+ */
 public class Attributes {
-	private EnumMap<Attr, Integer> stats = new EnumMap<>(Attr.class);
-	public int get(Attr k) { return stats.getOrDefault(k, 0); }
-	public void set(Attr k, int v) { stats.put(k, Math.max(0, v)); }
-	public void add(Attr k, int d) { set(k, get(k) + d); }
-	
-	public EnumMap<Attr, Integer> getStarts() { return stats; }
-	public Attributes setStarts(EnumMap<Attr, Integer> starts) { this.stats = starts; return this; }
 
-	public Map<Attr, Integer>view() { return Map.copyOf(stats); }
+    /** Giá trị hiện tại của các thuộc tính */
+    private EnumMap<Attr, Integer> stats = new EnumMap<>(Attr.class);
+
+    /** Giá trị tối đa của các thuộc tính (máu tối đa, pep tối đa, exp cần để lên cấp...) */
+    private EnumMap<Attr, Integer> maxStats = new EnumMap<>(Attr.class);
+
+    /**
+     * Lấy giá trị hiện tại của thuộc tính.
+     */
+    public int get(Attr k) { return stats.getOrDefault(k, 0); }
+
+    /**
+     * Gán giá trị hiện tại của thuộc tính (đã clamp ≥0 và ≤ max nếu có).
+     */
+    public void set(Attr k, int v) {
+        int max = maxStats.getOrDefault(k, Integer.MAX_VALUE);
+        stats.put(k, Math.max(0, Math.min(v, max)));
+    }
+
+    /**
+     * Tăng/giảm giá trị thuộc tính, tự động kẹp trong khoảng [0, max].
+     */
+    public void add(Attr k, int d) { set(k, get(k) + d); }
+
+    /**
+     * Lấy giá trị tối đa của thuộc tính.
+     */
+    public int getMax(Attr k) { return maxStats.getOrDefault(k, 0); }
+
+    /**
+     * Gán giá trị tối đa của thuộc tính.
+     */
+    public void setMax(Attr k, int v) {
+        maxStats.put(k, Math.max(0, v));
+        // đảm bảo giá trị hiện tại không vượt quá max mới
+        set(k, get(k));
+    }
+
+    /**
+     * Trả về bản sao không thể chỉnh sửa của map thuộc tính hiện tại.
+     */
+    public Map<Attr, Integer> view() { return Map.copyOf(stats); }
+
+    public EnumMap<Attr, Integer> getStarts() { return stats; }
+    public Attributes setStarts(EnumMap<Attr, Integer> starts) { this.stats = starts; return this; }
 }
+

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -33,7 +33,8 @@ public class HealthPotion extends Item {
 	@Override
     public void use(Player p) {
         int current = p.atts().get(Attr.HEALTH);
-        int newHealth = Math.min(current + healthAmount, 100);
+        int max = p.atts().getMax(Attr.HEALTH);
+        int newHealth = Math.min(current + healthAmount, max);
         p.atts().set(Attr.HEALTH, newHealth);
         decreaseQuantity(1);
 }

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -1,0 +1,55 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+
+/**
+ * Item dùng để tăng chỉ số Spirit (kinh nghiệm) cho người chơi.
+ * Sử dụng hình ảnh bình thuốc có sẵn.
+ */
+public class SpiritPotion extends Item {
+
+    private static BufferedImage icon;
+    private final int spiritAmount;
+
+    static {
+        try {
+            // Tái sử dụng icon của HealthPotion
+            icon = ImageIO.read(SpiritPotion.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public SpiritPotion(int spiritAmount, int quantity) {
+        super("Đan dược tinh thần", "Tăng Spirit", quantity, 100);
+        this.spiritAmount = spiritAmount;
+    }
+
+    @Override
+    public void use(Player p) {
+        // tăng Spirit và kiểm tra lên cấp
+        p.gainSpirit(spiritAmount);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new SpiritPotion(spiritAmount, qty);
+    }
+
+    @Override
+    public boolean isSameStack(Item other) {
+        if (!(other instanceof SpiritPotion sp)) return false;
+        return this.getName().equals(other.getName()) && this.spiritAmount == sp.spiritAmount;
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/enums/Affinity.java
+++ b/src/game/enums/Affinity.java
@@ -1,0 +1,26 @@
+package game.enums;
+
+/**
+ * Các loại linh căn (Affinity) mà nhân vật có thể sở hữu.
+ */
+public enum Affinity {
+    HOA("Hỏa"),
+    MOC("Mộc"),
+    THUY("Thủy"),
+    KIM("Kim"),
+    THO("Thổ"),
+    LOI("Lôi");
+
+    private final String display;
+
+    Affinity(String display) {
+        this.display = display;
+    }
+
+    /**
+     * @return tên hiển thị của linh căn.
+     */
+    public String getDisplay() {
+        return display;
+    }
+}

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -1,0 +1,41 @@
+package game.enums;
+
+/**
+ * Thể chất đặc biệt của nhân vật.
+ * Một số thể chất ảnh hưởng đến số tầng tối đa hoặc chỉ số khi lên cấp.
+ */
+public enum Physique {
+    NORMAL("Bình thường", 10, 1.0, 1.0, 1.0),
+    HU_KHONG("Hư không", 15, 1.0, 1.0, 1.0),
+    HU_KHONG_DAI_DE("Hư không đại đế", 20, 1.0, 1.0, 1.0),
+    THANH_THE("Thánh Thể", 10, 1.0, 2.0, 1.0),
+    TIEN_LINH_THE("Tiên Linh Thể", 10, 1.0/3.0, 1.0, 1.0),
+    THAN_THE("Thần Thể", 10, 1.0, 1.0, 1.0),
+    NGU_HANH("Ngũ Hành Linh Căn", 10, 1.0, 1.0, 5.0);
+
+    private final String display;
+    private final int maxStage;
+    private final double spiritReqFactor;
+    private final double defFactor;
+    private final double statFactor;
+
+    Physique(String display, int maxStage, double spiritReqFactor,
+             double defFactor, double statFactor) {
+        this.display = display;
+        this.maxStage = maxStage;
+        this.spiritReqFactor = spiritReqFactor;
+        this.defFactor = defFactor;
+        this.statFactor = statFactor;
+    }
+
+    /** @return tên hiển thị của thể chất */
+    public String getDisplay() { return display; }
+    /** @return số tầng tối đa trong mỗi đại cảnh giới */
+    public int getMaxStage() { return maxStage; }
+    /** @return hệ số giảm yêu cầu Spirit */
+    public double getSpiritReqFactor() { return spiritReqFactor; }
+    /** @return hệ số cộng dồn cho DEF */
+    public double getDefFactor() { return defFactor; }
+    /** @return hệ số cộng dồn cho toàn bộ chỉ số */
+    public double getStatFactor() { return statFactor; }
+}

--- a/src/game/enums/Realm.java
+++ b/src/game/enums/Realm.java
@@ -1,11 +1,12 @@
 package game.enums;
 
 /**
- * Cảnh giới tu luyện của nhân vật.
- * Hiện tại mới chỉ có cấp "Phàm nhân" mặc định.
+ * Các đại cảnh giới tu luyện của nhân vật.
  */
 public enum Realm {
-    PHAM_NHAN("Phàm nhân");
+    PHAM_NHAN("Phàm nhân"),
+    LUYEN_THE("Luyện thể"),
+    LUYEN_KHI("Luyện khí");
 
     private final String displayName;
 
@@ -13,6 +14,9 @@ public enum Realm {
         this.displayName = displayName;
     }
 
+    /**
+     * @return tên hiển thị của cảnh giới.
+     */
     public String getDisplayName() {
         return displayName;
     }

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -21,9 +21,6 @@ public class GameHUD {
     private static final Color EXP_FILL = new Color(250, 150, 40);
     private static final Color BAR_BACK = new Color(30, 30, 30, 180);
     private static final Color BAR_BORDER = new Color(0, 0, 0, 180);
-    private static final int MAX_HEALTH = 100;
-    private static final int MAX_PEP = 100;
-    private static final int MAX_SPIRIT = 100;
 
     public GameHUD(GamePanel gp) {
         this.gp = gp;
@@ -36,7 +33,7 @@ public class GameHUD {
         int margin = 5;
 
         // draw realm box
-        String realmText = p.getRealm().getDisplayName();
+        String realmText = p.getRealmName();
         int boxWidth = g2.getFontMetrics().stringWidth(realmText) + 20;
         int boxHeight = barHeight;
         HUDUtils.drawSubWindow(g2, margin, margin, boxWidth, boxHeight, BAR_BACK, BAR_BORDER);
@@ -47,13 +44,13 @@ public class GameHUD {
         int y = margin;
 
         drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.HEALTH), MAX_HEALTH, HP_FILL);
+                p.atts().get(Attr.HEALTH), p.atts().getMax(Attr.HEALTH), HP_FILL);
         y += barHeight + 6;
         drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.PEP), MAX_PEP, MP_FILL);
+                p.atts().get(Attr.PEP), p.atts().getMax(Attr.PEP), MP_FILL);
         y += barHeight + 6;
         drawBar(g2, x, y, barWidth, barHeight,
-                p.atts().get(Attr.SPIRIT), MAX_SPIRIT, EXP_FILL);
+                p.atts().get(Attr.SPIRIT), p.atts().getMax(Attr.SPIRIT), EXP_FILL);
     }
 
     private void drawBar(Graphics2D g2, int x, int y, int w, int h,

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -10,6 +10,7 @@ import java.awt.event.MouseEvent;
 import java.util.List;
 
 import game.entity.item.Item;
+import game.enums.Attr;
 import game.main.GamePanel;
 
 /**
@@ -197,11 +198,19 @@ public class InventoryUi {
         int textX = x + gp.getTileSize();
         int textY = y + gp.getTileSize();
 
-        var attrs = gp.getPlayer().atts();
-        for(game.enums.Attr a : game.enums.Attr.values()) {
-            g2.drawString(a.displayerName() + ": " + attrs.get(a), textX, textY);
-            textY += 30;
-        }
+        var p = gp.getPlayer();
+        var attrs = p.atts();
+
+        g2.drawString("Realm: " + p.getRealmName(), textX, textY); textY += 30;
+        g2.drawString("Health: " + attrs.get(Attr.HEALTH) + "/" + attrs.getMax(Attr.HEALTH), textX, textY); textY += 30;
+        g2.drawString("Pep: " + attrs.get(Attr.PEP) + "/" + attrs.getMax(Attr.PEP), textX, textY); textY += 30;
+        g2.drawString("Spirit: " + attrs.get(Attr.SPIRIT) + "/" + p.getSpiritToNextLevel(), textX, textY); textY += 30;
+        g2.drawString("Attack: " + attrs.get(Attr.ATTACK), textX, textY); textY += 30;
+        g2.drawString("Def: " + attrs.get(Attr.DEF), textX, textY); textY += 30;
+        g2.drawString("Strength: " + attrs.get(Attr.STRENGTH), textX, textY); textY += 30;
+        g2.drawString("Sould: " + attrs.get(Attr.SOULD), textX, textY); textY += 30;
+        g2.drawString("Physique: " + p.getPhysique().getDisplay(), textX, textY); textY += 30;
+        g2.drawString("Affinity: " + p.getAffinityNames(), textX, textY);
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {


### PR DESCRIPTION
## Summary
- track current and max attributes so values persist after item use
- introduce Physique and Affinity systems with random generation for each character
- add multi-realm cultivation with Spirit-based leveling and SpiritPotion test item

## Testing
- `javac -d /tmp/gameclasses $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68ab35e5f5c8832fbbcb3a882480e9bf