### PR TITLE
feat: export player stats to text file

### DIFF
--- a/src/game/entity/inventory/Inventory.java
+++ b/src/game/entity/inventory/Inventory.java
@@ -34,10 +34,14 @@ public class Inventory {
         }
     }
     
-	public boolean remove(Item i) {
-		return items.remove(i);
-	}
-	public List<Item> all(){
-		return List.copyOf(items);
-	}
+        public boolean remove(Item i) {
+                return items.remove(i);
+        }
+        public List<Item> all(){
+                return List.copyOf(items);
+        }
+
+    public void clear() {
+        items.clear();
+    }
 }

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -316,7 +316,7 @@ public abstract class Monster extends GameActor {
      */
     public void dropItem() {
         if (random.nextInt(100) < getDropChance()) {
-            gp.getPlayer().getBag().add(new game.entity.item.elixir.HealthPotion(30, 1));
+            gp.getPlayer().addItem(new game.entity.item.elixir.HealthPotion(30, 1));
         }
     }
 

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -71,13 +71,13 @@ public class GamePanel extends JPanel implements Runnable {
 	}
 	
 	public void setUpGame() { 
-		player.getBag().add(new HealthPotion(30, 50));
-		player.getBag().add(new HealthPotion(30, 60));  // 50+60 => 100 trong ô đầu + 10 sang ô mới
-		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(50, 1));
-		player.getBag().add(new HealthPotion(30, 60));
-		player.getBag().add(new HealthPotion(390, 60));
+                player.addItem(new HealthPotion(30, 50));
+                player.addItem(new HealthPotion(30, 60));  // 50+60 => 100 trong ô đầu + 10 sang ô mới
+                player.addItem(new HealthPotion(50, 1));
+                player.addItem(new HealthPotion(50, 1));
+                player.addItem(new HealthPotion(50, 1));
+                player.addItem(new HealthPotion(30, 60));
+                player.addItem(new HealthPotion(390, 60));
 		
                 objectManager.setObject();
                 objectManager.setEntity();


### PR DESCRIPTION
## Summary
- log player realm progress and inventory to `player.<name>.<date>.txt`
- add `addItem` helper so inventory changes are saved
- update item additions to use new helper

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68abd30f2960832fbb4c72a59e57b89f