### PR TITLE
Điều chỉnh hệ số tăng cấp cảnh giới

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 ## Cập nhật
 
+## [1.0.5] - 2025-08-25
+
+### Thay đổi
+- Điều chỉnh hệ thống tăng cấp theo **Cảnh giới**:
+  - Luyện thể và Luyện khí tăng chỉ số theo công thức mới.
+  - Đột phá đại cảnh giới nhân đôi (hoặc gấp ba với DEF) chỉ số và cộng thêm Linh hồn.
+- Bổ sung file `level_changes.txt` mô tả chi tiết hệ số mới.
+
 ## [1.0.4] - 2025-08-09
 
 ### Thêm

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 ## Cập nhật
 
+## [1.0.6] - 2025-08-25
+
+### Sửa lỗi
+- Gỡ giới hạn Attack/Def để chỉ số tăng đúng khi thăng cấp.
+- Thể chất **Ngũ Hành** yêu cầu SPIRIT gấp 5 lần so với thể chất khác.
+
 ## [1.0.5] - 2025-08-25
 
 ### Thay đổi

--- a/level_changes.txt
+++ b/level_changes.txt
@@ -1,0 +1,14 @@
+Các chỉnh sửa hệ thống tăng cấp:
+- Luyện thể/Luyện khí: mỗi lần tăng tiểu cảnh giới
+  + HEALTH, PEP: cộng stage * 50.
+  + ATTACK: +1, riêng bội số của 3 cộng thêm chính số đó.
+  + DEF: +1, nếu là bội số của 3 cộng thêm stage/2 (làm tròn lên).
+  + SPIRIT yêu cầu: cộng thêm một nửa SPIRIT yêu cầu hiện tại.
+  + STRENGTH: cộng 1 khi đạt bội số của 3.
+- Đột phá từ Luyện thể → Luyện khí
+  + HEALTH, ATTACK, PEP, SPIRIT, STRENGTH, SOULD: x2.
+  + DEF: x3.
+  + SOULD nhận thêm 10 điểm.
+- Khi tăng đại cảnh giới bất kỳ nhận thêm 10 SOULD.
+
+File này mô tả các thay đổi để so sánh với yêu cầu ban đầu.

--- a/level_changes.txt
+++ b/level_changes.txt
@@ -11,4 +11,8 @@ Các chỉnh sửa hệ thống tăng cấp:
   + SOULD nhận thêm 10 điểm.
 - Khi tăng đại cảnh giới bất kỳ nhận thêm 10 SOULD.
 
+Sửa lỗi:
+- Attack và Def không còn bị giới hạn 5/4, có thể tăng khi lên cấp.
+- Thể chất Ngũ Hành yêu cầu SPIRIT gấp 5 lần thể chất thường.
+
 File này mô tả các thay đổi để so sánh với yêu cầu ban đầu.

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -94,9 +94,8 @@ public class Player extends GameActor implements DrawableEntity {
             atts().set(Attr.PEP, 100);
             atts().setMax(Attr.SPIRIT, spiritToNextLevel);
             atts().set(Attr.SPIRIT, 0);
-            atts().setMax(Attr.ATTACK, 5);
+            // Attack/Def không còn giới hạn max mặc định để có thể tăng khi lên cấp
             atts().set(Attr.ATTACK, 5);
-            atts().setMax(Attr.DEF, 4);
             atts().set(Attr.DEF, 4);
             atts().set(Attr.STRENGTH, 1);
             atts().set(Attr.SOULD, 5);
@@ -104,6 +103,10 @@ public class Player extends GameActor implements DrawableEntity {
             // Thiết lập thể chất và linh căn ngẫu nhiên
             physique = randomPhysique();
             affinities = randomAffinities();
+
+            // Ngũ Hành Linh Căn có chỉ số gấp 5 lần nên yêu cầu SPIRIT cũng gấp 5
+            spiritToNextLevel = (int) (spiritToNextLevel * physique.getSpiritReqFactor());
+            atts().setMax(Attr.SPIRIT, spiritToNextLevel);
 
             // Thêm vài item test: bình hồi máu & tinh thần
             addItem(new game.entity.item.elixir.HealthPotion(50, 3));

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -11,7 +11,8 @@ public enum Physique {
     THANH_THE("Thánh Thể", 10, 1.0, 2.0, 1.0),
     TIEN_LINH_THE("Tiên Linh Thể", 10, 1.0/3.0, 1.0, 1.0),
     THAN_THE("Thần Thể", 10, 1.0, 1.0, 1.0),
-    NGU_HANH("Ngũ Hành Linh Căn", 10, 1.0, 1.0, 5.0);
+    // Ngũ Hành: chỉ số gấp 5 lần nên yêu cầu SPIRIT cũng gấp 5
+    NGU_HANH("Ngũ Hành Linh Căn", 10, 5.0, 1.0, 5.0);
 
     private final String display;
     private final int maxStage;


### PR DESCRIPTION
## Summary
- Áp dụng công thức mới cho việc tăng tiểu cảnh giới: HEALTH/PEP +50\*stage, bonus ATTACK/DEF/STRENGTH theo bội số 3
- Đột phá Luyện thể -> Luyện khí nhân đôi hầu hết chỉ số, DEF x3 và cộng thêm Linh hồn
- Thêm tài liệu `level_changes.txt` và cập nhật README

## Testing
- `javac @sources.list -d bin`

------
https://chatgpt.com/codex/tasks/task_e_68abedd9ff00832fb1d72280340f38a4