### PR TITLE
Add cultivation skills and pills

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,8 @@
+Cập nhật:
+- Thêm hệ thống kỹ năng cơ bản và lớp Skill.
+- Tạo công pháp tu luyện 4 phẩm cấp cùng sách học tương ứng.
+- Thêm đan dược tăng tốc tu luyện 4 phẩm cấp, hiệu lực 10 phút.
+- Nhân vật có thể tu luyện, kèm nút Huỷ và thời gian hồi chiêu 1 giờ.
+- HUD hiển thị buff đan dược và nút hủy khi đang tu luyện.
+- Bảng thuộc tính có nút mở danh sách công pháp.
+- Định dạng file lưu tiến trình bổ sung dòng SKILL.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 ## Cập nhật
 
+## [1.0.7] - 2025-08-26
+
+### Thêm
+- Hệ thống **Kỹ năng** cơ bản với class `Skill` dễ mở rộng.
+- 4 công pháp tu luyện (hạ, trung, thượng, cực phẩm) học qua sách.
+- 4 loại đan dược tăng tốc tu luyện, cộng thêm SPIRIT mỗi giây trong 10 phút.
+- Tu luyện đứng im, có nút **Huỷ** ở HUD và hồi chiêu 1 giờ.
+- HUD hiển thị tên đan dược đang dùng và thời gian đếm ngược.
+- Bảng thuộc tính có nút mở danh sách công pháp.
+- Tệp lưu người chơi thêm mục `SKILL` ghi lại công pháp đã học.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/player.Nguyeen_pro.20250825.txt
+++ b/player.Nguyeen_pro.20250825.txt
@@ -1,5 +1,5 @@
 ============player.Nguyeen_pro.20250825.txt==============
-Itemcủa nhân vật: Đan dược hồi máu (3), Đan dược tinh thần (3), Đan dược hồi máu (100), Đan dược hồi máu (10), Đan dược tinh thần (42), Đan dược tinh thần (60)
+Itemcủa nhân vật: Đan dược hồi máu (3), Đan dược tinh thần (3), Đan dược hồi máu (100), Đan dược hồi máu (10), Đan dược tinh thần (42), Đan dược tinh thần (60), Sách Công pháp hạ phẩm (1), Sách Công pháp trung phẩm (1), Sách Công pháp thượng phẩm (1), Sách Công pháp cực phẩm (1), Đan hạ phẩm (1), Đan trung phẩm (1), Đan thượng phẩm (1), Đan cực phẩm (1)
 =============================
 cảnh giới phàm nhân - 2025-08-25 13:23:08
 HEALTH: 100
@@ -11,6 +11,7 @@ SPIRIT 1000
 STRENGTH: 1
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 1 - 2025-08-25 13:23:19
@@ -23,6 +24,7 @@ SPIRIT 1500
 STRENGTH: 2
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 2 - 2025-08-25 13:23:21
@@ -35,6 +37,7 @@ SPIRIT 2250
 STRENGTH: 2
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 3 - 2025-08-25 13:23:25
@@ -47,6 +50,7 @@ SPIRIT 3375
 STRENGTH: 3
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 4 - 2025-08-25 13:23:26
@@ -59,6 +63,7 @@ SPIRIT 5062
 STRENGTH: 3
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 5 - 2025-08-25 13:23:28
@@ -71,6 +76,7 @@ SPIRIT 7593
 STRENGTH: 3
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 6 - 2025-08-25 13:23:30
@@ -83,6 +89,7 @@ SPIRIT 11389
 STRENGTH: 4
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 7 - 2025-08-25 13:23:32
@@ -95,6 +102,7 @@ SPIRIT 17083
 STRENGTH: 4
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 8 - 2025-08-25 13:23:36
@@ -107,6 +115,7 @@ SPIRIT 25624
 STRENGTH: 4
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 9 - 2025-08-25 13:23:38
@@ -119,6 +128,7 @@ SPIRIT 38436
 STRENGTH: 5
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện thể tầng 10 - 2025-08-25 13:23:41
@@ -131,6 +141,7 @@ SPIRIT 57654
 STRENGTH: 5
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện khí tầng 1 - 2025-08-25 13:23:42
@@ -143,6 +154,7 @@ SPIRIT 115308
 STRENGTH: 10
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện khí tầng 2 - 2025-08-25 13:23:45
@@ -155,6 +167,7 @@ SPIRIT 172962
 STRENGTH: 10
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 
 =============================
 cảnh giới luyện khí tầng 3 - 2025-08-25 13:23:49
@@ -167,4 +180,5 @@ SPIRIT 259443
 STRENGTH: 11
 PHYSIQUE: Bình thường
 AFFINITY: Thủy
+SKILL: None
 

--- a/src/game/entity/item/book/CultivationBook.java
+++ b/src/game/entity/item/book/CultivationBook.java
@@ -1,0 +1,48 @@
+package game.entity.item.book;
+
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+import game.skill.CultivationTechnique;
+
+/**
+ * Sách dùng để học công pháp tu luyện.
+ */
+public class CultivationBook extends Item {
+    private static BufferedImage icon;
+    private final CultivationTechnique technique;
+
+    static {
+        try {
+            // Tạm dùng icon bình thuốc làm placeholder
+            icon = ImageIO.read(CultivationBook.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public CultivationBook(CultivationTechnique tech) {
+        super("Sách " + tech.getName(), "Học " + tech.getName(), 1, 1);
+        this.technique = tech;
+    }
+
+    @Override
+    public void use(Player p) {
+        p.learnSkill(technique);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        CultivationBook b = new CultivationBook(technique);
+        b.setQuantity(qty);
+        return b;
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/entity/item/elixir/CultivationPill.java
+++ b/src/game/entity/item/elixir/CultivationPill.java
@@ -1,0 +1,52 @@
+package game.entity.item.elixir;
+
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+import game.entity.item.Item;
+
+/**
+ * Đan dược tăng tốc độ tu luyện. Khi sử dụng sẽ tăng thêm SPIRIT mỗi giây
+ * trong 10 phút.
+ */
+public class CultivationPill extends Item {
+    private static BufferedImage icon;
+    private final int spiritBonus;
+
+    static {
+        try {
+            // Tạm dùng icon bình thuốc sẵn có
+            icon = ImageIO.read(CultivationPill.class.getResourceAsStream("/data/item/elixir/HealthPotion.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public CultivationPill(String name, int spiritBonus, int quantity) {
+        super(name, "Tăng tốc độ tu luyện", quantity, 100);
+        this.spiritBonus = spiritBonus;
+    }
+
+    @Override
+    public void use(Player p) {
+        p.consumeCultivationPill(getName(), spiritBonus, 10 * 60 * 1000L);
+        decreaseQuantity(1);
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new CultivationPill(getName(), spiritBonus, qty);
+    }
+
+    @Override
+    public boolean isSameStack(Item other) {
+        if (!(other instanceof CultivationPill cp)) return false;
+        return getName().equals(cp.getName()) && spiritBonus == cp.spiritBonus;
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/enums/SkillGrade.java
+++ b/src/game/enums/SkillGrade.java
@@ -1,0 +1,33 @@
+package game.enums;
+
+/**
+ * Phẩm cấp của kỹ năng/công pháp.
+ */
+public enum SkillGrade {
+    HA("Hạ phẩm"),
+    TRUNG("Trung phẩm"),
+    THUONG("Thượng phẩm"),
+    CUC("Cực phẩm");
+
+    private final String display;
+
+    SkillGrade(String display) {
+        this.display = display;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    /**
+     * Tìm enum theo chuỗi hiển thị.
+     */
+    public static SkillGrade fromDisplay(String text) {
+        for (SkillGrade g : values()) {
+            if (g.display.equalsIgnoreCase(text)) {
+                return g;
+            }
+        }
+        return HA;
+    }
+}

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -14,13 +14,14 @@ public class MouseHandler implements MouseListener {
     public void mouseClicked(MouseEvent e) { }
     @Override
     public void mousePressed(MouseEvent e) {
-            if (gp.keyH.isiPressed()) {
-                if (gp.getUi().handleInventoryMousePress(e.getX(), e.getY(), e.getButton())) {
-                    return;
-                }
-                return;
-            }
-            // Right mouse pressed
+        // Ưu tiên xử lý click cho UI (kho đồ, nút hủy, bảng công pháp...)
+        if (gp.getUi().handleInventoryMousePress(e.getX(), e.getY(), e.getButton())) {
+            return;
+        }
+        if (gp.keyH.isiPressed()) {
+            return;
+        }
+        // Right mouse pressed
         if (e.getButton() == MouseEvent.BUTTON3) {
             //Tọa độ x,y trên màn hình
             int mouseX = e.getX();

--- a/src/game/skill/CultivationTechnique.java
+++ b/src/game/skill/CultivationTechnique.java
@@ -1,0 +1,27 @@
+package game.skill;
+
+import game.entity.Player;
+import game.enums.SkillGrade;
+
+/**
+ * Công pháp tu luyện, cho phép người chơi tu luyện để nhận SPIRIT theo thời gian.
+ */
+public class CultivationTechnique extends Skill {
+    private final int durationMinutes;
+    private final int spiritPerSecond;
+
+    public CultivationTechnique(String name, SkillGrade grade, int level,
+                                int durationMinutes, int spiritPerSecond) {
+        super(name, "Công pháp tu luyện", grade, level);
+        this.durationMinutes = durationMinutes;
+        this.spiritPerSecond = spiritPerSecond;
+    }
+
+    public int getSpiritPerSecond() { return spiritPerSecond; }
+    public long getDurationMillis() { return durationMinutes * 60L * 1000L; }
+
+    @Override
+    public void use(Player p) {
+        p.startCultivating(this);
+    }
+}

--- a/src/game/skill/Skill.java
+++ b/src/game/skill/Skill.java
@@ -1,0 +1,32 @@
+package game.skill;
+
+import game.entity.Player;
+import game.enums.SkillGrade;
+
+/**
+ * Lớp cơ sở cho mọi loại kỹ năng trong game.
+ */
+public abstract class Skill {
+    private final String name;
+    private final String description;
+    private final SkillGrade grade;
+    private int level;
+
+    protected Skill(String name, String description, SkillGrade grade, int level) {
+        this.name = name;
+        this.description = description;
+        this.grade = grade;
+        this.level = level;
+    }
+
+    public String getName() { return name; }
+    public String getDescription() { return description; }
+    public SkillGrade getGrade() { return grade; }
+    public int getLevel() { return level; }
+    public void levelUp() { level++; }
+
+    /**
+     * Thực thi kỹ năng.
+     */
+    public abstract void use(Player p);
+}

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -2,6 +2,8 @@ package game.ui;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.event.MouseEvent;
 
 import game.entity.Player;
 import game.enums.Attr;
@@ -22,8 +24,14 @@ public class GameHUD {
     private static final Color BAR_BACK = new Color(30, 30, 30, 180);
     private static final Color BAR_BORDER = new Color(0, 0, 0, 180);
 
+    private final Rectangle cancelRect;
+
     public GameHUD(GamePanel gp) {
         this.gp = gp;
+        // Nút hủy tu luyện nằm góc trái dưới màn hình
+        int w = 80;
+        int h = 30;
+        this.cancelRect = new Rectangle(5, gp.getScreenHeight() - h - 5, w, h);
     }
 
     public void draw(Graphics2D g2) {
@@ -51,6 +59,22 @@ public class GameHUD {
         y += barHeight + 6;
         drawBar(g2, x, y, barWidth, barHeight,
                 p.atts().get(Attr.SPIRIT), p.atts().getMax(Attr.SPIRIT), EXP_FILL);
+
+        // Hiển thị thông tin buff đan dược dưới thanh SPIRIT
+        if (p.getPillSpiritBonus() > 0) {
+            long sec = p.getPillTimeLeft() / 1000;
+            String text = p.getActivePillName() + " " + (sec / 60) + ":" + String.format("%02d", sec % 60);
+            g2.setColor(Color.WHITE);
+            g2.drawString(text, x, y + barHeight + 20);
+        }
+
+        // Nếu đang tu luyện, vẽ nút hủy
+        if (p.isCultivating()) {
+            HUDUtils.drawSubWindow(g2, cancelRect.x, cancelRect.y, cancelRect.width, cancelRect.height,
+                    BAR_BACK, BAR_BORDER);
+            g2.setColor(Color.WHITE);
+            g2.drawString("Huỷ", cancelRect.x + 20, cancelRect.y + cancelRect.height - 10);
+        }
     }
 
     private void drawBar(Graphics2D g2, int x, int y, int w, int h,
@@ -62,5 +86,14 @@ public class GameHUD {
         g2.fillRect(x, y, filled, h);
         g2.setColor(BAR_BORDER);
         g2.drawRect(x, y, w, h);
+    }
+
+    /** Xử lý click chuột trên HUD. */
+    public boolean handleMousePress(int mx, int my, int button) {
+        if (button == MouseEvent.BUTTON1 && gp.getPlayer().isCultivating() && cancelRect.contains(mx, my)) {
+            gp.getPlayer().cancelCultivation();
+            return true;
+        }
+        return false;
     }
 }

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -27,6 +27,7 @@ public class InventoryUi {
     private String[] contextOptions = new String[0];
     private int contextSelection = 0;
     private int contextX, contextY;
+    private java.awt.Rectangle skillBtn = new java.awt.Rectangle();
 
     public InventoryUi(GamePanel gp) {
         this.gp = gp;
@@ -210,7 +211,17 @@ public class InventoryUi {
         g2.drawString("Strength: " + attrs.get(Attr.STRENGTH), textX, textY); textY += 30;
         g2.drawString("Sould: " + attrs.get(Attr.SOULD), textX, textY); textY += 30;
         g2.drawString("Physique: " + p.getPhysique().getDisplay(), textX, textY); textY += 30;
-        g2.drawString("Affinity: " + p.getAffinityNames(), textX, textY);
+        g2.drawString("Affinity: " + p.getAffinityNames(), textX, textY); textY += 40;
+
+        // Vẽ nút mở bảng công pháp
+        int btnW = gp.getTileSize() * 4;
+        int btnH = gp.getTileSize();
+        int btnX = x + (width - btnW) / 2;
+        int btnY = y + height - btnH - gp.getTileSize() / 2;
+        HUDUtils.drawSubWindow(g2, btnX, btnY, btnW, btnH, new Color(40,40,40,200), Color.WHITE);
+        g2.setColor(Color.WHITE);
+        g2.drawString("Công pháp", btnX + 20, btnY + btnH - 10);
+        skillBtn.setBounds(btnX, btnY, btnW, btnH);
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {
@@ -231,6 +242,11 @@ public class InventoryUi {
             baseX = gp.getScreenWidth() - d.width - gp.getTileSize() / 2;
         }
         int baseY = gp.getTileSize() * 2; // match grid position in draw()
+        if (skillBtn.contains(mx, my)) {
+            gp.getUi().getSkillUi().toggle();
+            return true;
+        }
+
         int idx = computeSlotIndex(baseX, baseY, new Point(mx, my));
         var items = gp.getPlayer().getBag().all();
         if (idx >= 0 && idx < itemGrid.getCols() * itemGrid.getRows()) {

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -1,0 +1,60 @@
+package game.ui;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.event.MouseEvent;
+import java.util.List;
+
+import game.main.GamePanel;
+import game.skill.CultivationTechnique;
+
+/**
+ * Bảng hiển thị danh sách công pháp đã học.
+ */
+public class SkillUi {
+    private final GamePanel gp;
+    private boolean visible = false;
+    private Rectangle[] entries = new Rectangle[0];
+
+    public SkillUi(GamePanel gp) {
+        this.gp = gp;
+    }
+
+    public void draw(Graphics2D g2) {
+        if (!visible) return;
+        int x = gp.getTileSize() * 2;
+        int y = gp.getTileSize();
+        int w = gp.getTileSize() * 8;
+        int h = gp.getTileSize() * 6;
+        HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
+        List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
+        entries = new Rectangle[skills.size()];
+        for (int i = 0; i < skills.size(); i++) {
+            int yy = y + 40 + i * 40;
+            g2.setColor(Color.WHITE);
+            g2.drawString(skills.get(i).getName(), x + 30, yy);
+            entries[i] = new Rectangle(x + 20, yy - 25, w - 40, 30);
+        }
+    }
+
+    public boolean handleMousePress(int mx, int my, int button) {
+        if (!visible) return false;
+        if (button == MouseEvent.BUTTON1) {
+            for (int i = 0; i < entries.length; i++) {
+                if (entries[i].contains(mx, my)) {
+                    var list = gp.getPlayer().getTechniques();
+                    if (i < list.size()) {
+                        list.get(i).use(gp.getPlayer());
+                        visible = false;
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public void toggle() { visible = !visible; }
+    public boolean isVisible() { return visible; }
+}

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -26,6 +26,7 @@ public class Ui {
 
     private final InventoryUi inventory;
     private final GameHUD hud;
+    private final SkillUi skillUi;
     
     private int damageCounter = 0;
 
@@ -35,6 +36,7 @@ public class Ui {
         this.arial_80B = new Font("Arial", Font.BOLD, 80);
         this.inventory = new InventoryUi(gp);
         this.hud = new GameHUD(gp);
+        this.skillUi = new SkillUi(gp);
     }
 
     public void showMessage(String text) {
@@ -56,6 +58,9 @@ public class Ui {
         }
         if (gp.keyH.isiPressed()) {
             inventory.draw(g2);
+            if (skillUi.isVisible()) {
+                skillUi.draw(g2);
+            }
         }
         hud.draw(g2);
         if (damageCounter > 0) {
@@ -66,7 +71,9 @@ public class Ui {
     }
 
     public boolean handleInventoryMousePress(int mx, int my, int button) {
-        return inventory.handleMousePress(mx, my, button);
+        if (inventory.handleMousePress(mx, my, button)) return true;
+        if (skillUi.handleMousePress(mx, my, button)) return true;
+        return hud.handleMousePress(mx, my, button);
     }
 
     private void drawInteractionHint(Graphics2D g2) {
@@ -155,6 +162,7 @@ public class Ui {
     public Ui setCurrentDialogue(String currentDialogue) { this.currentDialogue = currentDialogue; return this; }
 
     public InventoryUi getInventory() { return inventory; }
+    public SkillUi getSkillUi() { return skillUi; }
     
     public void triggerDamageEffect() { damageCounter = 10; }
 }


### PR DESCRIPTION
## Summary
- add base `Skill` system with cultivation techniques and grades
- introduce cultivation pills and books for 4 ranks
- show cancel button and pill buffs on HUD; profile file logs learned skills

## Testing
- `javac -d bin $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68ac49de6314832f8410b05fa50ced04