### PR TITLE
Adjust cultivation to fixed one-hour sessions with timers

### DIFF
--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -128,10 +128,10 @@ public class Player extends GameActor implements DrawableEntity {
             addItem(new game.entity.item.elixir.SpiritPotion(200, 3));
 
             // Các sách công pháp và đan dược tu luyện để thử nghiệm
-            var low = new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 5, 1);
-            var mid = new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 10, 2);
-            var high = new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 15, 3);
-            var top = new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 25, 5);
+            var low = new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1);
+            var mid = new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 2);
+            var high = new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 3);
+            var top = new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 5);
             addItem(new game.entity.item.book.CultivationBook(low));
             addItem(new game.entity.item.book.CultivationBook(mid));
             addItem(new game.entity.item.book.CultivationBook(high));
@@ -442,7 +442,7 @@ public class Player extends GameActor implements DrawableEntity {
         cultivating = true;
         activeTechnique = tech;
         lastSpiritTick = now;
-        cultivationEndTime = now + tech.getDurationMillis();
+        cultivationEndTime = now + 3600_000L;
     }
 
     public void cancelCultivation() {
@@ -466,6 +466,15 @@ public class Player extends GameActor implements DrawableEntity {
             lastSpiritTick += 1000;
             gainSpirit(activeTechnique.getSpiritPerSecond() + pillSpiritBonus);
         }
+    }
+
+    public long getCultivationCooldownRemaining() {
+        return Math.max(0, cultivationCooldownEnd - System.currentTimeMillis());
+    }
+
+    public long getCultivationTimeLeft() {
+        if (!cultivating) return 0;
+        return Math.max(0, cultivationEndTime - System.currentTimeMillis());
     }
 
     public boolean isCultivating() { return cultivating; }
@@ -755,7 +764,14 @@ public class Player extends GameActor implements DrawableEntity {
                             String name = (i1 > 0) ? tk.substring(0, i1).trim() : tk.trim();
                             int lvl = (i1 > 0 && i2 > i1) ? Integer.parseInt(tk.substring(i1 + 1, i2)) : 1;
                             String gradeStr = (i3 > i2 && i4 > i3) ? tk.substring(i3 + 1, i4) : SkillGrade.HA.getDisplay();
-                            techniques.add(new CultivationTechnique(name, SkillGrade.fromDisplay(gradeStr), lvl, 0, 0));
+                            SkillGrade grade = SkillGrade.fromDisplay(gradeStr);
+                            int sps = switch (grade) {
+                                case HA -> 1;
+                                case TRUNG -> 2;
+                                case THUONG -> 3;
+                                case CUC -> 5;
+                            };
+                            techniques.add(new CultivationTechnique(name, grade, lvl, sps));
                         }
                     }
                 }
@@ -807,10 +823,10 @@ public class Player extends GameActor implements DrawableEntity {
             case "Đan trung phẩm" -> new game.entity.item.elixir.CultivationPill("Đan trung phẩm", 2, qty);
             case "Đan thượng phẩm" -> new game.entity.item.elixir.CultivationPill("Đan thượng phẩm", 3, qty);
             case "Đan cực phẩm" -> new game.entity.item.elixir.CultivationPill("Đan cực phẩm", 4, qty);
-            case "Sách Công pháp hạ phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 5, 1));
-            case "Sách Công pháp trung phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 10, 2));
-            case "Sách Công pháp thượng phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 15, 3));
-            case "Sách Công pháp cực phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 25, 5));
+            case "Sách Công pháp hạ phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1));
+            case "Sách Công pháp trung phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 2));
+            case "Sách Công pháp thượng phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 3));
+            case "Sách Công pháp cực phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 5));
             default -> null;
         };
     }

--- a/src/game/skill/CultivationTechnique.java
+++ b/src/game/skill/CultivationTechnique.java
@@ -7,18 +7,15 @@ import game.enums.SkillGrade;
  * Công pháp tu luyện, cho phép người chơi tu luyện để nhận SPIRIT theo thời gian.
  */
 public class CultivationTechnique extends Skill {
-    private final int durationMinutes;
     private final int spiritPerSecond;
 
     public CultivationTechnique(String name, SkillGrade grade, int level,
-                                int durationMinutes, int spiritPerSecond) {
+                                int spiritPerSecond) {
         super(name, "Công pháp tu luyện", grade, level);
-        this.durationMinutes = durationMinutes;
         this.spiritPerSecond = spiritPerSecond;
     }
 
     public int getSpiritPerSecond() { return spiritPerSecond; }
-    public long getDurationMillis() { return durationMinutes * 60L * 1000L; }
 
     @Override
     public void use(Player p) {

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -60,12 +60,19 @@ public class GameHUD {
         drawBar(g2, x, y, barWidth, barHeight,
                 p.atts().get(Attr.SPIRIT), p.atts().getMax(Attr.SPIRIT), EXP_FILL);
 
-        // Hiển thị thông tin buff đan dược dưới thanh SPIRIT
+        int infoY = y + barHeight + 20;
         if (p.getPillSpiritBonus() > 0) {
             long sec = p.getPillTimeLeft() / 1000;
             String text = p.getActivePillName() + " " + (sec / 60) + ":" + String.format("%02d", sec % 60);
             g2.setColor(Color.WHITE);
-            g2.drawString(text, x, y + barHeight + 20);
+            g2.drawString(text, x, infoY);
+            infoY += 20;
+        }
+        if (p.isCultivating()) {
+            long sec = p.getCultivationTimeLeft() / 1000;
+            String text = "Tu luyện: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
+            g2.setColor(Color.WHITE);
+            g2.drawString(text, x, infoY);
         }
 
         // Nếu đang tu luyện, vẽ nút hủy

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -30,10 +30,16 @@ public class SkillUi {
         HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
         List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
         entries = new Rectangle[skills.size()];
+        long cd = gp.getPlayer().getCultivationCooldownRemaining();
         for (int i = 0; i < skills.size(); i++) {
             int yy = y + 40 + i * 40;
             g2.setColor(Color.WHITE);
             g2.drawString(skills.get(i).getName(), x + 30, yy);
+            if (cd > 0) {
+                String cdStr = formatTime(cd);
+                int strW = g2.getFontMetrics().stringWidth(cdStr);
+                g2.drawString(cdStr, x + w - 30 - strW, yy);
+            }
             entries[i] = new Rectangle(x + 20, yy - 25, w - 40, 30);
         }
     }
@@ -57,4 +63,11 @@ public class SkillUi {
 
     public void toggle() { visible = !visible; }
     public boolean isVisible() { return visible; }
+
+    private String formatTime(long ms) {
+        long sec = ms / 1000;
+        long min = sec / 60;
+        long s = sec % 60;
+        return String.format("%02d:%02d", min, s);
+    }
 }


### PR DESCRIPTION
## Summary
- Remove per-technique durations so cultivation always lasts one hour
- Display remaining cultivation cooldown beside each technique
- Show active cultivation timer under the SPIRIT bar

## Testing
- `javac -d bin @sources.txt && echo "Compiled"`


------
https://chatgpt.com/codex/tasks/task_e_68ac5ee14110832f821781ad63587017