### PR TITLE
feat: enhance skill interface and saving

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -12,3 +12,9 @@ Sửa lỗi và cải tiến:
 - HUD hiển thị thời gian hồi chiêu tu luyện.
 - Kho đồ thu nhỏ ô 32px và có thanh cuộn để chứa nhiều item.
 - Khung thuộc tính dùng font nhỏ, lề sát hơn để tránh đè giao diện.
+
+## 1.0.8
+- Sửa lỗi bảng công pháp không hiển thị thời gian hồi chiêu.
+- Bảng công pháp chuyển sang bên phải, có nút **Dùng** và **Gán**, tooltip chi tiết và cuộn bằng con lăn.
+- Kho đồ hỗ trợ cuộn bằng con lăn chuột.
+- Hồ sơ .txt ghi thêm công pháp khi học mới.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
 - Ô chứa item nhỏ 32px, kho có thêm thanh cuộn để tránh tràn.
 - Khung thuộc tính thu gọn, chữ cỡ nhỏ và căn lề sát hơn.
 
+## [1.0.8] - 2025-08-27
+
+### Thêm
+- Bảng công pháp chuyển sang bên phải, có nút **Dùng**/**Gán**, hiển thị hồi chiêu và tooltip khi hover.
+- Kho đồ hỗ trợ cuộn bằng con lăn chuột.
+
+### Sửa lỗi
+- Hồi chiêu công pháp hiển thị đầy đủ trong HUD và bảng công pháp.
+- Công pháp học mới được lưu vào tệp `.txt` ngay lập tức.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/fix_summary.txt
+++ b/fix_summary.txt
@@ -1,0 +1,6 @@
+- Sửa lỗi không hiển thị thời gian hồi chiêu công pháp.
+- Bảng công pháp chuyển sang bên phải, thêm nút Dùng/Gán, tooltip, và hỗ trợ cuộn bằng con lăn.
+- Kho đồ hỗ trợ cuộn bằng chuột, lưu lại vị trí để cuộn chính xác.
+- Khi học công pháp mới sẽ lưu ngay vào tệp .txt.
+- HUD hiển thị thời gian hồi chiêu khi không tu luyện.
+- Cập nhật README và Change.txt.

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -425,7 +425,21 @@ public class Player extends GameActor implements DrawableEntity {
     /** Người chơi học một công pháp mới. */
     public void learnSkill(CultivationTechnique tech) {
         techniques.add(tech);
+        // Lưu lại tiến trình ngay sau khi học để đảm bảo
+        // công pháp tồn tại khi thoát game.
+        logRealmState();
+        saveProfile();
     }
+
+    // Công pháp được gán vào phím nhanh (tạm thời lưu 1 kỹ năng).
+    private CultivationTechnique assignedTechnique;
+
+    /** Gán một công pháp cho phím nhanh. */
+    public void assignTechnique(CultivationTechnique tech) {
+        assignedTechnique = tech;
+    }
+
+    public CultivationTechnique getAssignedTechnique() { return assignedTechnique; }
 
     public List<CultivationTechnique> getTechniques() { return List.copyOf(techniques); }
 

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -65,11 +65,12 @@ public class GamePanel extends JPanel implements Runnable {
 	public GamePanel() {
 		this.setPreferredSize(new Dimension(screenWidth, screenHeight));
 		this.setBackground(Color.white);
-		this.setDoubleBuffered(true);
-		this.addKeyListener(keyH);
-		this.addMouseListener(mounseH);
-		this.setFocusable(true);
-	}
+                this.setDoubleBuffered(true);
+                this.addKeyListener(keyH);
+                this.addMouseListener(mounseH);
+                this.addMouseWheelListener(mounseH);
+                this.setFocusable(true);
+        }
 	
 	public void setUpGame() { 
         player.addItem(new HealthPotion(30, 50));

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -2,10 +2,15 @@ package game.mouseclick;
 
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 
 import game.main.GamePanel;
 
-public class MouseHandler implements MouseListener {
+/**
+ * Xử lý các sự kiện chuột cho trò chơi.
+ */
+public class MouseHandler implements MouseListener, MouseWheelListener {
     public int targetX, targetY;
     public boolean moving = false;
     GamePanel gp;
@@ -42,6 +47,11 @@ public class MouseHandler implements MouseListener {
     public void mouseEntered(MouseEvent e) { }
     @Override
     public void mouseExited(MouseEvent e) { }
+
+    @Override
+    public void mouseWheelMoved(MouseWheelEvent e) {
+        gp.getUi().handleMouseWheel(e.getWheelRotation(), e.getX(), e.getY());
+    }
     public int getTargetX() { return targetX; }
     public MouseHandler setTargetX(int targetX) { this.targetX = targetX; return this; }
     public int getTargetY() { return targetY; }

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -70,6 +70,13 @@ public class GameHUD {
             String text = "Tu luyện: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
             g2.setColor(Color.WHITE);
             g2.drawString(text, x, infoY);
+            infoY += 20;
+        } else if (p.getCultivationCooldownRemaining() > 0) {
+            long sec = p.getCultivationCooldownRemaining() / 1000;
+            String text = "Hồi chiêu: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
+            g2.setColor(Color.WHITE);
+            g2.drawString(text, x, infoY);
+            infoY += 20;
         }
 
         // Nếu đang tu luyện, vẽ nút hủy

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -24,6 +24,9 @@ public class InventoryUi {
     private int selectedSlot = 0; // chỉ số item toàn cục đang chọn
     private int hoverSlot = -1;   // chỉ số item toàn cục đang trỏ vào
     private int scrollOffset = 0; // vị trí bắt đầu của trang hiện tại
+    // Lưu lại toạ độ khung để dùng cho cuộn bằng chuột.
+    private int lastGridX, lastGridY;
+    private java.awt.Dimension lastDim = new java.awt.Dimension();
     private boolean contextVisible = false;
     private String[] contextOptions = new String[0];
     private int contextSelection = 0;
@@ -49,6 +52,9 @@ public class InventoryUi {
         int outerY = gridY - gp.getTileSize() / 2; // keep margin similar to original
         int outerW = gridX + d.width + gp.getTileSize() / 2 - outerX;
         int outerH = Math.max(charH, d.height) + gp.getTileSize();
+        lastGridX = gridX;
+        lastGridY = gridY;
+        lastDim.setSize(d);
         HUDUtils.drawSubWindow(g2, outerX, outerY, outerW, outerH,
                 new Color(40,40,40,180), Color.YELLOW);
 
@@ -190,6 +196,22 @@ public class InventoryUi {
         g2.setColor(Color.WHITE);
         g2.drawString(line1, x + padding, y + padding + 15);
         g2.drawString(line2, x + padding, y + padding + 35);
+    }
+
+    /** Xử lý cuộn bằng con lăn chuột. */
+    public void handleMouseWheel(int rotation, int mx, int my) {
+        if (!(mx >= lastGridX && mx <= lastGridX + lastDim.width &&
+              my >= lastGridY && my <= lastGridY + lastDim.height)) {
+            return;
+        }
+        int cols = itemGrid.getCols();
+        int rows = itemGrid.getRows();
+        int visible = cols * rows;
+        int total = gp.getPlayer().getBag().all().size();
+        int maxOffset = Math.max(0, total - visible);
+        scrollOffset += Integer.signum(rotation) * cols;
+        if (scrollOffset < 0) scrollOffset = 0;
+        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
     }
 
     /**

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -2,52 +2,165 @@ package game.ui;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
-import game.main.GamePanel;
 import game.entity.skill.CultivationTechnique;
+import game.main.GamePanel;
 
 /**
- * Bảng hiển thị danh sách công pháp đã học.
+ * Bảng hiển thị và tương tác với danh sách công pháp.
  */
 public class SkillUi {
     private final GamePanel gp;
     private boolean visible = false;
-    private Rectangle[] entries = new Rectangle[0];
 
-    public SkillUi(GamePanel gp) {
-        this.gp = gp;
+    /** Vị trí cuộn hiện tại. */
+    private int scrollOffset = 0;
+
+    /** Các ô kỹ năng đang được vẽ. */
+    private Entry[] entries = new Entry[0];
+
+    /** Chỉ số ô đang hover để hiển thị tooltip. */
+    private int hoverIndex = -1;
+
+    // Lưu toạ độ cuối cùng của khung để kiểm tra vị trí cuộn.
+    private Rectangle lastBounds = new Rectangle();
+
+    /** Thông tin hiển thị trên một dòng kỹ năng. */
+    private static class Entry {
+        Rectangle area;       // vùng cho toàn bộ dòng
+        Rectangle useBtn;     // nút sử dụng
+        Rectangle assignBtn;  // nút gán
+        CultivationTechnique tech;
     }
 
+    public SkillUi(GamePanel gp) { this.gp = gp; }
+
+    /**
+     * Vẽ bảng công pháp ở phía bên phải màn hình.
+     */
     public void draw(Graphics2D g2) {
         if (!visible) return;
-        int x = gp.getTileSize() * 2;
-        int y = gp.getTileSize();
-        int w = gp.getTileSize() * 8;
-        int h = gp.getTileSize() * 6;
+
+        int tile = gp.getTileSize();
+        int w = tile * 8;
+        int h = tile * 6;
+        int x = gp.getScreenWidth() - w - tile; // dịch sang phải
+        int y = tile;
+        lastBounds.setBounds(x, y, w, h);
+
         HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
+
         List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
-        entries = new Rectangle[skills.size()];
-        for (int i = 0; i < skills.size(); i++) {
-            int yy = y + 40 + i * 40;
+        int lineH = 40;
+        int visibleLines = Math.max(1, (h - 60) / lineH);
+
+        // Giới hạn offset nằm trong [0, tổng - hiển thị]
+        int maxOffset = Math.max(0, skills.size() - visibleLines);
+        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
+        if (scrollOffset < 0) scrollOffset = 0;
+
+        entries = new Entry[skills.size()];
+        Point mouse = gp.getMousePosition();
+        hoverIndex = -1;
+
+        for (int i = scrollOffset; i < skills.size() && i < scrollOffset + visibleLines; i++) {
+            CultivationTechnique tech = skills.get(i);
+            int idx = i - scrollOffset;
+            int yy = y + 40 + idx * lineH;
+
+            Entry e = new Entry();
+            e.tech = tech;
+            e.area = new Rectangle(x + 20, yy - 25, w - 40, 30);
+            int btnW = 60, btnH = 25;
+            e.useBtn = new Rectangle(x + w - btnW*2 - 30, yy - 20, btnW, btnH);
+            e.assignBtn = new Rectangle(x + w - btnW - 15, yy - 20, btnW, btnH);
+            entries[i] = e;
+
+            // Highlight khi hover
+            if (mouse != null && e.area.contains(mouse)) {
+                hoverIndex = i;
+                g2.setColor(new Color(80,80,80,150));
+                g2.fill(e.area);
+            }
+
             g2.setColor(Color.WHITE);
-            g2.drawString(skills.get(i).getName(), x + 30, yy);
-            entries[i] = new Rectangle(x + 20, yy - 25, w - 40, 30);
+            String name = tech.getName();
+            long cd = gp.getPlayer().getCultivationCooldownRemaining();
+            if (cd > 0) {
+                long sec = cd / 1000;
+                name += " (" + (sec/60) + ":" + String.format("%02d", sec%60) + ")";
+            }
+            g2.drawString(name, x + 30, yy);
+
+            // Vẽ nút "Sử dụng"
+            HUDUtils.drawSubWindow(g2, e.useBtn.x, e.useBtn.y, e.useBtn.width, e.useBtn.height,
+                    new Color(50,50,50,180), Color.WHITE);
+            g2.drawString("Dùng", e.useBtn.x + 12, e.useBtn.y + 18);
+
+            // Vẽ nút "Gán"
+            HUDUtils.drawSubWindow(g2, e.assignBtn.x, e.assignBtn.y, e.assignBtn.width, e.assignBtn.height,
+                    new Color(50,50,50,180), Color.WHITE);
+            g2.drawString("Gán", e.assignBtn.x + 15, e.assignBtn.y + 18);
+        }
+
+        // Thanh cuộn đơn giản
+        if (skills.size() > visibleLines) {
+            int trackH = h - 40;
+            int barH = Math.max(20, visibleLines * trackH / skills.size());
+            int barY = y + 20 + scrollOffset * (trackH - barH) / (skills.size() - visibleLines);
+            g2.setColor(new Color(120,120,120));
+            g2.fillRect(x + w - 15, y + 20, 8, trackH);
+            g2.setColor(Color.DARK_GRAY);
+            g2.fillRect(x + w - 15, barY, 8, barH);
+        }
+
+        // Tooltip khi hover
+        if (hoverIndex >= 0 && hoverIndex < skills.size()) {
+            CultivationTechnique tech = skills.get(hoverIndex);
+            String line1 = tech.getName();
+            String line2 = "Cấp: " + tech.getLevel();
+            String line3 = "Phẩm cấp: " + tech.getGrade().getDisplay();
+            long sec = gp.getPlayer().getCultivationCooldownRemaining() / 1000;
+            String line4 = "Hồi chiêu: " + (sec/60) + ":" + String.format("%02d", sec%60);
+
+            int padding = 10;
+            int width = Math.max(Math.max(g2.getFontMetrics().stringWidth(line1),
+                                         g2.getFontMetrics().stringWidth(line2)),
+                                 Math.max(g2.getFontMetrics().stringWidth(line3),
+                                          g2.getFontMetrics().stringWidth(line4))) + padding*2;
+            int height = 80 + padding*2;
+            int tipX = (mouse != null ? mouse.x + 15 : x + w + 10);
+            int tipY = (mouse != null ? mouse.y + 15 : y + 20);
+            if (tipX + width > gp.getScreenWidth()) tipX = gp.getScreenWidth() - width - 10;
+            if (tipY + height > gp.getScreenHeight()) tipY = gp.getScreenHeight() - height - 10;
+            HUDUtils.drawSubWindow(g2, tipX, tipY, width, height, new Color(40,40,40,200), Color.YELLOW);
+            g2.setColor(Color.WHITE);
+            g2.drawString(line1, tipX + padding, tipY + padding + 15);
+            g2.drawString(line2, tipX + padding, tipY + padding + 35);
+            g2.drawString(line3, tipX + padding, tipY + padding + 55);
+            g2.drawString(line4, tipX + padding, tipY + padding + 75);
         }
     }
 
+    /**
+     * Xử lý click chuột cho bảng công pháp.
+     */
     public boolean handleMousePress(int mx, int my, int button) {
         if (!visible) return false;
         if (button == MouseEvent.BUTTON1) {
-            for (int i = 0; i < entries.length; i++) {
-                if (entries[i].contains(mx, my)) {
-                    var list = gp.getPlayer().getTechniques();
-                    if (i < list.size()) {
-                        list.get(i).use(gp.getPlayer());
-                        visible = false;
-                    }
+            for (Entry e : entries) {
+                if (e == null) continue;
+                if (e.useBtn.contains(mx, my)) {
+                    e.tech.use(gp.getPlayer());
+                    visible = false;
+                    return true;
+                }
+                if (e.assignBtn.contains(mx, my)) {
+                    gp.getPlayer().assignTechnique(e.tech);
                     return true;
                 }
             }
@@ -55,6 +168,16 @@ public class SkillUi {
         return false;
     }
 
+    /**
+     * Cuộn danh sách bằng con lăn chuột.
+     */
+    public void handleMouseWheel(int rotation, int mx, int my) {
+        if (!visible) return;
+        if (!lastBounds.contains(mx, my)) return;
+        scrollOffset += Integer.signum(rotation);
+    }
+
     public void toggle() { visible = !visible; }
     public boolean isVisible() { return visible; }
 }
+

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -76,6 +76,15 @@ public class Ui {
         return hud.handleMousePress(mx, my, button);
     }
 
+    /**
+     * Xử lý sự kiện cuộn chuột cho các bảng UI đang mở.
+     */
+    public void handleMouseWheel(int rotation, int mx, int my) {
+        if (!gp.keyH.isiPressed()) return;
+        inventory.handleMouseWheel(rotation, mx, my);
+        skillUi.handleMouseWheel(rotation, mx, my);
+    }
+
     private void drawInteractionHint(Graphics2D g2) {
         List<Entity> nearbyNpcs = gp.getCheckCollision().getEntitiesInRange(gp.getPlayer(), gp.getNpcs(), 48);
         if (!nearbyNpcs.isEmpty()) {


### PR DESCRIPTION
## Summary
- show skill cooldown in HUD and skill list, and save learned techniques immediately
- redesign skill UI with use/assign buttons, tooltip hover, right-side panel and mouse-wheel scrolling
- enable mouse-wheel scrolling in inventory

## Testing
- `javac -d bin $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68ac676c22e4832f8bc36c62b1bacad5