### PR TITLE
Improve skill UI and cooldown tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 ## Cập nhật
 
+## [1.0.8] - 2025-08-27
+
+### Thêm
+- Bảng công pháp di chuyển sang bên phải, có nút **Dùng** và **Gán** cùng tooltip khi rê chuột.
+- Hiển thị thời gian hồi chiêu cạnh tên công pháp và trong HUD.
+- Danh sách công pháp và kho đồ hỗ trợ cuộn bằng con lăn chuột.
+
+### Sửa lỗi
+- Tệp lưu ghi lại công pháp đã học và thời gian hồi chiêu sau khi thoát game.
+
 ## [1.0.7] - 2025-08-26
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -71,6 +71,8 @@ public class Player extends GameActor implements DrawableEntity {
 
     // Danh sách công pháp đã học
     private final List<CultivationTechnique> techniques = new ArrayList<>();
+    /** Công pháp được gán phím nóng (dùng sau này). */
+    private CultivationTechnique assignedTechnique;
     // Trạng thái tu luyện
     private boolean cultivating = false;
     private CultivationTechnique activeTechnique;
@@ -425,9 +427,14 @@ public class Player extends GameActor implements DrawableEntity {
     /** Người chơi học một công pháp mới. */
     public void learnSkill(CultivationTechnique tech) {
         techniques.add(tech);
+        saveProfile();
     }
 
     public List<CultivationTechnique> getTechniques() { return List.copyOf(techniques); }
+
+    /** Gán công pháp vào phím nóng để sử dụng sau này. */
+    public void assignTechnique(CultivationTechnique tech) { assignedTechnique = tech; saveProfile(); }
+    public CultivationTechnique getAssignedTechnique() { return assignedTechnique; }
 
     public String getSkillSummary() {
         if (techniques.isEmpty()) return "None";
@@ -610,7 +617,7 @@ public class Player extends GameActor implements DrawableEntity {
         spiritToNextLevel = (int) (oldReq * 2 * physique.getSpiritReqFactor());
     }
 
-    private void logRealmState() {
+    private String buildRealmState() {
         String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         StringBuilder sb = new StringBuilder();
         sb.append("=============================\n");
@@ -625,12 +632,24 @@ public class Player extends GameActor implements DrawableEntity {
         sb.append("PHYSIQUE: " + physique.getDisplay() + "\n");
         sb.append("AFFINITY: " + getAffinityNames() + "\n");
         sb.append("SKILL: " + getSkillSummary() + "\n");
-        realmLog.add(sb.toString());
+        return sb.toString();
+    }
+
+    private void logRealmState() {
+        realmLog.add(buildRealmState());
+    }
+
+    /** Cập nhật nhật ký cảnh giới với thông tin hiện tại. */
+    private void updateCurrentRealmLog() {
+        String current = buildRealmState();
+        if (realmLog.isEmpty()) realmLog.add(current);
+        else realmLog.set(realmLog.size() - 1, current);
     }
 
     private void saveProfile() {
         try {
             Path file = getProfilePath();
+            updateCurrentRealmLog();
             List<String> lines = new ArrayList<>();
             String fileName = file.getFileName().toString();
             lines.add("============" + fileName + "==============");

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -65,11 +65,12 @@ public class GamePanel extends JPanel implements Runnable {
 	public GamePanel() {
 		this.setPreferredSize(new Dimension(screenWidth, screenHeight));
 		this.setBackground(Color.white);
-		this.setDoubleBuffered(true);
-		this.addKeyListener(keyH);
-		this.addMouseListener(mounseH);
-		this.setFocusable(true);
-	}
+                this.setDoubleBuffered(true);
+                this.addKeyListener(keyH);
+                this.addMouseListener(mounseH);
+                this.addMouseWheelListener(mounseH);
+                this.setFocusable(true);
+        }
 	
 	public void setUpGame() { 
         player.addItem(new HealthPotion(30, 50));

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -2,10 +2,12 @@ package game.mouseclick;
 
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 
 import game.main.GamePanel;
 
-public class MouseHandler implements MouseListener {
+public class MouseHandler implements MouseListener, MouseWheelListener {
     public int targetX, targetY;
     public boolean moving = false;
     GamePanel gp;
@@ -42,6 +44,10 @@ public class MouseHandler implements MouseListener {
     public void mouseEntered(MouseEvent e) { }
     @Override
     public void mouseExited(MouseEvent e) { }
+    @Override
+    public void mouseWheelMoved(MouseWheelEvent e) {
+        gp.getUi().handleMouseWheel(e.getWheelRotation());
+    }
     public int getTargetX() { return targetX; }
     public MouseHandler setTargetX(int targetX) { this.targetX = targetX; return this; }
     public int getTargetY() { return targetY; }

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -70,6 +70,13 @@ public class GameHUD {
             String text = "Tu luyện: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
             g2.setColor(Color.WHITE);
             g2.drawString(text, x, infoY);
+            infoY += 20;
+        } else if (p.getCultivationCooldownRemaining() > 0) {
+            long sec = p.getCultivationCooldownRemaining() / 1000;
+            String text = "Hồi: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
+            g2.setColor(Color.WHITE);
+            g2.drawString(text, x, infoY);
+            infoY += 20;
         }
 
         // Nếu đang tu luyện, vẽ nút hủy

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -193,6 +193,24 @@ public class InventoryUi {
     }
 
     /**
+     * Cuộn kho đồ bằng con lăn chuột.
+     */
+    public boolean handleMouseWheel(int rotation) {
+        int cols = itemGrid.getCols();
+        int rows = itemGrid.getRows();
+        var items = gp.getPlayer().getBag().all();
+        int visible = cols * rows;
+        int maxOffset = Math.max(0, items.size() - visible);
+        scrollOffset += rotation * cols; // cuộn mỗi lần một hàng
+        if (scrollOffset < 0) scrollOffset = 0;
+        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
+        // đảm bảo ô chọn nằm trong trang hiện tại
+        if (selectedSlot < scrollOffset) selectedSlot = scrollOffset;
+        if (selectedSlot >= scrollOffset + visible) selectedSlot = scrollOffset + visible - 1;
+        return true;
+    }
+
+    /**
      * Draws the character attribute box at a given vertical offset.
      *
      * @param topY starting Y position of the box

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -2,12 +2,13 @@ package game.ui;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
-import game.main.GamePanel;
 import game.entity.skill.CultivationTechnique;
+import game.main.GamePanel;
 
 /**
  * Bảng hiển thị danh sách công pháp đã học.
@@ -15,7 +16,11 @@ import game.entity.skill.CultivationTechnique;
 public class SkillUi {
     private final GamePanel gp;
     private boolean visible = false;
+    private int scrollOffset = 0;
     private Rectangle[] entries = new Rectangle[0];
+    private Rectangle[] useBtns = new Rectangle[0];
+    private Rectangle[] assignBtns = new Rectangle[0];
+    private int firstIndex = 0; // index của skill đầu tiên đang hiển thị
 
     public SkillUi(GamePanel gp) {
         this.gp = gp;
@@ -23,31 +28,95 @@ public class SkillUi {
 
     public void draw(Graphics2D g2) {
         if (!visible) return;
-        int x = gp.getTileSize() * 2;
-        int y = gp.getTileSize();
         int w = gp.getTileSize() * 8;
         int h = gp.getTileSize() * 6;
+        int x = gp.getScreenWidth() - w - gp.getTileSize(); // dịch sang bên phải
+        int y = gp.getTileSize();
         HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
+
         List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
-        entries = new Rectangle[skills.size()];
-        for (int i = 0; i < skills.size(); i++) {
-            int yy = y + 40 + i * 40;
+        int rowH = 40;
+        int visibleRows = (h - 40) / rowH;
+        int total = skills.size();
+        int maxOffset = Math.max(0, total - visibleRows);
+        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
+        firstIndex = scrollOffset;
+        int end = Math.min(total, scrollOffset + visibleRows);
+        int count = end - scrollOffset;
+        entries = new Rectangle[count];
+        useBtns = new Rectangle[count];
+        assignBtns = new Rectangle[count];
+
+        long cd = gp.getPlayer().getCultivationCooldownRemaining();
+        for (int i = 0; i < count; i++) {
+            int skillIdx = scrollOffset + i;
+            int yy = y + 40 + i * rowH;
+            CultivationTechnique tech = skills.get(skillIdx);
+            String name = tech.getName();
+            if (cd > 0) {
+                name += " (" + formatTime(cd) + ")";
+            }
             g2.setColor(Color.WHITE);
-            g2.drawString(skills.get(i).getName(), x + 30, yy);
+            g2.drawString(name, x + 30, yy);
+
+            int btnW = 50, btnH = 25;
+            int useX = x + w - btnW * 2 - 30;
+            int btnY = yy - 20;
+            useBtns[i] = new Rectangle(useX, btnY, btnW, btnH);
+            HUDUtils.drawSubWindow(g2, useX, btnY, btnW, btnH, new Color(40,40,40,200), Color.WHITE);
+            g2.drawString("Dùng", useX + 8, btnY + 17);
+
+            int assignX = x + w - btnW - 20;
+            assignBtns[i] = new Rectangle(assignX, btnY, btnW, btnH);
+            HUDUtils.drawSubWindow(g2, assignX, btnY, btnW, btnH, new Color(40,40,40,200), Color.WHITE);
+            g2.drawString("Gán", assignX + 10, btnY + 17);
+
             entries[i] = new Rectangle(x + 20, yy - 25, w - 40, 30);
+        }
+
+        // Thanh cuộn
+        if (total > visibleRows) {
+            int trackH = h - 40;
+            int barH = Math.max(20, trackH * visibleRows / total);
+            int barY = y + 40;
+            if (maxOffset > 0) {
+                barY += (trackH - barH) * scrollOffset / maxOffset;
+            }
+            int barX = x + w - 8;
+            g2.setColor(new Color(255,255,255,150));
+            g2.fillRect(barX, barY, 4, barH);
+        }
+
+        // Tooltip khi hover
+        Point m = gp.getMousePosition();
+        if (m != null) {
+            for (int i = 0; i < entries.length; i++) {
+                if (entries[i].contains(m)) {
+                    int idx = firstIndex + i;
+                    if (idx < skills.size()) {
+                        drawSkillTooltip(g2, m.x + 15, m.y + 15, skills.get(idx));
+                    }
+                    break;
+                }
+            }
         }
     }
 
     public boolean handleMousePress(int mx, int my, int button) {
         if (!visible) return false;
         if (button == MouseEvent.BUTTON1) {
-            for (int i = 0; i < entries.length; i++) {
-                if (entries[i].contains(mx, my)) {
-                    var list = gp.getPlayer().getTechniques();
-                    if (i < list.size()) {
-                        list.get(i).use(gp.getPlayer());
-                        visible = false;
-                    }
+            List<CultivationTechnique> list = gp.getPlayer().getTechniques();
+            for (int i = 0; i < useBtns.length; i++) {
+                int idx = firstIndex + i;
+                if (idx >= list.size()) continue;
+                if (useBtns[i].contains(mx, my)) {
+                    list.get(idx).use(gp.getPlayer());
+                    visible = false;
+                    return true;
+                }
+                if (assignBtns[i].contains(mx, my)) {
+                    gp.getPlayer().assignTechnique(list.get(idx));
+                    visible = false;
                     return true;
                 }
             }
@@ -55,6 +124,44 @@ public class SkillUi {
         return false;
     }
 
+    /**
+     * Xử lý cuộn chuột.
+     */
+    public boolean handleMouseWheel(int rotation) {
+        if (!visible) return false;
+        int h = gp.getTileSize() * 6;
+        int rowH = 40;
+        int visibleRows = (h - 40) / rowH;
+        int total = gp.getPlayer().getTechniques().size();
+        int maxOffset = Math.max(0, total - visibleRows);
+        scrollOffset += rotation;
+        if (scrollOffset < 0) scrollOffset = 0;
+        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
+        return true;
+    }
+
     public void toggle() { visible = !visible; }
     public boolean isVisible() { return visible; }
+
+    private void drawSkillTooltip(Graphics2D g2, int x, int y, CultivationTechnique t) {
+        String line1 = t.getName();
+        String line2 = "Cấp: " + t.getLevel();
+        String line3 = "Phẩm: " + t.getGrade().getDisplay();
+        String line4 = "Hồi chiêu: " + formatTime(gp.getPlayer().getCultivationCooldownRemaining());
+        int padding = 10;
+        int width = Math.max(Math.max(g2.getFontMetrics().stringWidth(line1), g2.getFontMetrics().stringWidth(line2)),
+                Math.max(g2.getFontMetrics().stringWidth(line3), g2.getFontMetrics().stringWidth(line4))) + padding * 2;
+        int height = 80 + padding * 2;
+        HUDUtils.drawSubWindow(g2, x, y, width, height, new Color(40,40,40,200), new Color(200,200,200));
+        g2.setColor(Color.WHITE);
+        g2.drawString(line1, x + padding, y + padding + 15);
+        g2.drawString(line2, x + padding, y + padding + 30);
+        g2.drawString(line3, x + padding, y + padding + 45);
+        g2.drawString(line4, x + padding, y + padding + 60);
+    }
+
+    private String formatTime(long ms) {
+        long sec = ms / 1000;
+        return (sec / 60) + ":" + String.format("%02d", sec % 60);
+    }
 }

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -76,6 +76,12 @@ public class Ui {
         return hud.handleMousePress(mx, my, button);
     }
 
+    /** Xử lý cuộn chuột cho các bảng UI. */
+    public void handleMouseWheel(int rotation) {
+        inventory.handleMouseWheel(rotation);
+        skillUi.handleMouseWheel(rotation);
+    }
+
     private void drawInteractionHint(Graphics2D g2) {
         List<Entity> nearbyNpcs = gp.getCheckCollision().getEntitiesInRange(gp.getPlayer(), gp.getNpcs(), 48);
         if (!nearbyNpcs.isEmpty()) {

--- a/update_report.txt
+++ b/update_report.txt
@@ -1,0 +1,6 @@
+Các thay đổi chính:
+- Sửa lỗi không lưu công pháp đã học vào tệp và không hiển thị hồi chiêu.
+- HUD hiển thị thời gian hồi chiêu của tu luyện khi đang chờ.
+- Bảng công pháp di chuyển sang bên phải, có nút "Dùng" và "Gán", tooltip và thanh cuộn dùng con lăn chuột.
+- Kho đồ hỗ trợ cuộn bằng con lăn.
+- Định dạng file lưu giữ mục SKILL với cấp và phẩm của công pháp.


### PR DESCRIPTION
## Summary
- Save learned cultivation techniques and show cooldown in HUD
- Add scrollable skill list with tooltip, Use/Gán buttons, and mouse wheel support
- Support mouse wheel scrolling in inventory and moved skill panel to right

## Testing
- `javac -d bin $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68ac675b3358832faa7180f4ffc0c699