### PR TITLE
feat: enhance skill ui and cooldown tracking

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -12,3 +12,9 @@ Sửa lỗi và cải tiến:
 - HUD hiển thị thời gian hồi chiêu tu luyện.
 - Kho đồ thu nhỏ ô 32px và có thanh cuộn để chứa nhiều item.
 - Khung thuộc tính dùng font nhỏ, lề sát hơn để tránh đè giao diện.
+
+## [1.0.8] 2025-08-27
+- Bảng công pháp chuyển sang bên phải, thêm nút **Use**/**Gán** và tooltip chi tiết.
+- Hiển thị thời gian hồi chiêu cả trong HUD lẫn danh sách công pháp.
+- Danh sách công pháp và kho đồ hỗ trợ cuộn bằng con lăn chuột.
+- Tệp lưu bổ sung cấp độ/phẩm cấp công pháp và được cập nhật ngay khi học.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 ## Cập nhật
 
+## [1.0.8] - 2025-08-27
+
+### Thêm
+- Bảng **Công pháp** di chuyển sang bên phải, có nút *Use* và *Gán* cho từng kỹ năng.
+- Hiển thị thời gian hồi chiêu bên cạnh tên công pháp và trong HUD.
+- Tooltip và con lăn chuột hỗ trợ cuộn trong danh sách công pháp.
+- Kho đồ và bảng công pháp đều hỗ trợ cuộn bằng chuột.
+
+### Sửa lỗi
+- Sử dụng sách công pháp giờ được lưu vào tệp, nhân vật giữ nguyên công pháp sau khi thoát.
+
+### Cải thiện
+- Tệp lưu bổ sung thông tin công pháp với cấp độ và phẩm cấp.
+
 ## [1.0.7] - 2025-08-26
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -74,6 +74,8 @@ public class Player extends GameActor implements DrawableEntity {
     // Trạng thái tu luyện
     private boolean cultivating = false;
     private CultivationTechnique activeTechnique;
+    // Công pháp được gán phím nhanh (chưa dùng)
+    private CultivationTechnique assignedTechnique;
     private long cultivationEndTime = 0;
     private long cultivationCooldownEnd = 0;
     private long lastSpiritTick = 0;
@@ -422,9 +424,22 @@ public class Player extends GameActor implements DrawableEntity {
 
     // ------------ Hệ thống kỹ năng & tu luyện ------------
 
-    /** Người chơi học một công pháp mới. */
+    /** Người chơi học một công pháp mới và lưu lại hồ sơ. */
     public void learnSkill(CultivationTechnique tech) {
         techniques.add(tech);
+        // Cập nhật log để tệp lưu có danh sách công pháp mới
+        logRealmState();
+        saveProfile();
+    }
+
+    /** Gán công pháp vào phím tắt (hiện chưa sử dụng). */
+    public void assignTechnique(CultivationTechnique tech) {
+        assignedTechnique = tech;
+    }
+
+    /** Lấy công pháp đã gán phím tắt. */
+    public CultivationTechnique getAssignedTechnique() {
+        return assignedTechnique;
     }
 
     public List<CultivationTechnique> getTechniques() { return List.copyOf(techniques); }
@@ -628,7 +643,8 @@ public class Player extends GameActor implements DrawableEntity {
         realmLog.add(sb.toString());
     }
 
-    private void saveProfile() {
+    /** Lưu trạng thái hiện tại của nhân vật vào tệp. */
+    public void saveProfile() {
         try {
             Path file = getProfilePath();
             List<String> lines = new ArrayList<>();

--- a/src/game/entity/item/Item.java
+++ b/src/game/entity/item/Item.java
@@ -47,12 +47,11 @@ public abstract class Item {
     // Thực hiện hành động tương ứng
     public void performAction(Player p, String action) {
         if ("Use".equalsIgnoreCase(action)) {
-            use(p);
-            if (getQuantity() == 0) {
-                p.getBag().remove(this);
-            }
+            // Ủy quyền cho Player xử lý để tự động lưu tệp
+            p.useItem(this);
         } else if ("Drop".equalsIgnoreCase(action)) {
             p.getBag().remove(this);
+            p.saveProfile();
         }
     }
 

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -67,7 +67,8 @@ public class GamePanel extends JPanel implements Runnable {
 		this.setBackground(Color.white);
 		this.setDoubleBuffered(true);
 		this.addKeyListener(keyH);
-		this.addMouseListener(mounseH);
+                this.addMouseListener(mounseH);
+                this.addMouseWheelListener(mounseH);
 		this.setFocusable(true);
 	}
 	

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -2,10 +2,12 @@ package game.mouseclick;
 
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 
 import game.main.GamePanel;
 
-public class MouseHandler implements MouseListener {
+public class MouseHandler implements MouseListener, MouseWheelListener {
     public int targetX, targetY;
     public boolean moving = false;
     GamePanel gp;
@@ -42,6 +44,13 @@ public class MouseHandler implements MouseListener {
     public void mouseEntered(MouseEvent e) { }
     @Override
     public void mouseExited(MouseEvent e) { }
+
+    @Override
+    public void mouseWheelMoved(MouseWheelEvent e) {
+        if (gp.keyH.isiPressed()) {
+            gp.getUi().handleMouseWheel(e.getWheelRotation());
+        }
+    }
     public int getTargetX() { return targetX; }
     public MouseHandler setTargetX(int targetX) { this.targetX = targetX; return this; }
     public int getTargetY() { return targetY; }

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -70,6 +70,14 @@ public class GameHUD {
             String text = "Tu luyện: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
             g2.setColor(Color.WHITE);
             g2.drawString(text, x, infoY);
+        } else {
+            long cd = p.getCultivationCooldownRemaining();
+            if (cd > 0) {
+                long sec = cd / 1000;
+                String text = "Hồi chiêu: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
+                g2.setColor(Color.WHITE);
+                g2.drawString(text, x, infoY);
+            }
         }
 
         // Nếu đang tu luyện, vẽ nút hủy

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -192,6 +192,18 @@ public class InventoryUi {
         g2.drawString(line2, x + padding, y + padding + 35);
     }
 
+    /** Cuộn kho đồ bằng con lăn chuột. */
+    public void handleMouseWheel(int rotation) {
+        var items = gp.getPlayer().getBag().all();
+        int cols = itemGrid.getCols();
+        int rows = itemGrid.getRows();
+        int visible = cols * rows;
+        scrollOffset += rotation * cols;
+        int maxOffset = Math.max(0, items.size() - visible);
+        if (scrollOffset < 0) scrollOffset = 0;
+        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
+    }
+
     /**
      * Draws the character attribute box at a given vertical offset.
      *

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -2,57 +2,162 @@ package game.ui;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
-import game.main.GamePanel;
 import game.entity.skill.CultivationTechnique;
+import game.main.GamePanel;
 
 /**
  * Bảng hiển thị danh sách công pháp đã học.
+ * Hiển thị thời gian hồi chiêu, cho phép sử dụng/gán và hỗ trợ cuộn.
  */
 public class SkillUi {
     private final GamePanel gp;
     private boolean visible = false;
-    private Rectangle[] entries = new Rectangle[0];
+    private Rectangle[] entryRects = new Rectangle[0];
+    private Rectangle[] useBtns = new Rectangle[0];
+    private Rectangle[] assignBtns = new Rectangle[0];
+    private int scrollOffset = 0;
+    private int hoverIndex = -1;
 
-    public SkillUi(GamePanel gp) {
-        this.gp = gp;
-    }
+    public SkillUi(GamePanel gp) { this.gp = gp; }
 
+    /** Vẽ khung danh sách công pháp. */
     public void draw(Graphics2D g2) {
         if (!visible) return;
-        int x = gp.getTileSize() * 2;
-        int y = gp.getTileSize();
-        int w = gp.getTileSize() * 8;
-        int h = gp.getTileSize() * 6;
+        int tile = gp.getTileSize();
+        int w = tile * 6;
+        int h = tile * 6;
+        int x = gp.getScreenWidth() - w - tile; // nằm bên phải màn hình
+        int y = tile;
         HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
+
         List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
-        entries = new Rectangle[skills.size()];
-        for (int i = 0; i < skills.size(); i++) {
-            int yy = y + 40 + i * 40;
+        int entryH = 40;
+        int visibleCount = (h - 40) / entryH;
+        int total = skills.size();
+        entryRects = new Rectangle[Math.min(visibleCount, total)];
+        useBtns = new Rectangle[entryRects.length];
+        assignBtns = new Rectangle[entryRects.length];
+
+        Point m = gp.getMousePosition();
+        hoverIndex = -1;
+
+        for (int i = 0; i < visibleCount; i++) {
+            int idx = scrollOffset + i;
+            if (idx >= total) break;
+            int yy = y + 40 + i * entryH;
+            CultivationTechnique tech = skills.get(idx);
+            String name = tech.getName();
+            long cdMs = gp.getPlayer().getCultivationCooldownRemaining();
+            if (cdMs > 0) {
+                long sec = cdMs / 1000;
+                name += " (" + (sec / 60) + ":" + String.format("%02d", sec % 60) + ")";
+            }
             g2.setColor(Color.WHITE);
-            g2.drawString(skills.get(i).getName(), x + 30, yy);
-            entries[i] = new Rectangle(x + 20, yy - 25, w - 40, 30);
+            g2.drawString(name, x + 15, yy);
+
+            entryRects[i] = new Rectangle(x + 10, yy - 25, w - 20, 30);
+            int bw = 50, bh = 20;
+            int bxAssign = x + w - bw - 10;
+            int bxUse = bxAssign - bw - 10;
+            useBtns[i] = new Rectangle(bxUse, yy - 20, bw, bh);
+            assignBtns[i] = new Rectangle(bxAssign, yy - 20, bw, bh);
+
+            HUDUtils.drawSubWindow(g2, bxUse, yy - 20, bw, bh, new Color(60,60,60,200), Color.WHITE);
+            HUDUtils.drawSubWindow(g2, bxAssign, yy - 20, bw, bh, new Color(60,60,60,200), Color.WHITE);
+            g2.setColor(Color.WHITE);
+            g2.drawString("Use", bxUse + 10, yy - 5);
+            g2.drawString("Gán", bxAssign + 10, yy - 5);
+
+            if (m != null && entryRects[i].contains(m)) {
+                hoverIndex = idx;
+            }
+        }
+
+        // Vẽ thanh cuộn
+        if (total > visibleCount) {
+            int trackH = h - 40;
+            int barH = Math.max(20, trackH * visibleCount / total);
+            int maxOff = total - visibleCount;
+            int barY = y + 20;
+            if (maxOff > 0) {
+                barY += (trackH - barH) * scrollOffset / maxOff;
+            }
+            int barX = x + w - 5;
+            g2.setColor(new Color(255,255,255,150));
+            g2.fillRect(barX, barY, 3, barH);
+        }
+
+        // Tooltip khi hover
+        if (hoverIndex >= 0 && hoverIndex < total) {
+            drawTooltip(g2, m, skills.get(hoverIndex));
         }
     }
 
+    /** Vẽ tooltip thông tin công pháp. */
+    private void drawTooltip(Graphics2D g2, Point m, CultivationTechnique tech) {
+        if (m == null) return;
+        String l1 = tech.getName();
+        String l2 = "Cấp: " + tech.getLevel();
+        String l3 = "Phẩm: " + tech.getGrade().getDisplay();
+        long cdMs = gp.getPlayer().getCultivationCooldownRemaining();
+        String l4 = "Hồi chiêu: ";
+        if (cdMs > 0) {
+            long sec = cdMs / 1000;
+            l4 += (sec / 60) + ":" + String.format("%02d", sec % 60);
+        } else {
+            l4 += "0";
+        }
+        int pad = 10;
+        int width = Math.max(Math.max(g2.getFontMetrics().stringWidth(l1), g2.getFontMetrics().stringWidth(l2)),
+                Math.max(g2.getFontMetrics().stringWidth(l3), g2.getFontMetrics().stringWidth(l4))) + pad * 2;
+        int height = 100;
+        int x = m.x + 15;
+        int y = m.y + 15;
+        if (x + width > gp.getScreenWidth()) x = gp.getScreenWidth() - width - 10;
+        if (y + height > gp.getScreenHeight()) y = gp.getScreenHeight() - height - 10;
+        HUDUtils.drawSubWindow(g2, x, y, width, height, new Color(40,40,40,200), Color.WHITE);
+        g2.setColor(Color.WHITE);
+        g2.drawString(l1, x + pad, y + 20);
+        g2.drawString(l2, x + pad, y + 40);
+        g2.drawString(l3, x + pad, y + 60);
+        g2.drawString(l4, x + pad, y + 80);
+    }
+
+    /** Xử lý click chuột. */
     public boolean handleMousePress(int mx, int my, int button) {
         if (!visible) return false;
         if (button == MouseEvent.BUTTON1) {
-            for (int i = 0; i < entries.length; i++) {
-                if (entries[i].contains(mx, my)) {
-                    var list = gp.getPlayer().getTechniques();
-                    if (i < list.size()) {
-                        list.get(i).use(gp.getPlayer());
-                        visible = false;
-                    }
+            for (int i = 0; i < entryRects.length; i++) {
+                int idx = scrollOffset + i;
+                if (idx >= gp.getPlayer().getTechniques().size()) continue;
+                if (useBtns[i].contains(mx, my)) {
+                    gp.getPlayer().getTechniques().get(idx).use(gp.getPlayer());
+                    return true;
+                }
+                if (assignBtns[i].contains(mx, my)) {
+                    gp.getPlayer().assignTechnique(gp.getPlayer().getTechniques().get(idx));
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    /** Cuộn danh sách bằng con lăn chuột. */
+    public void handleMouseWheel(int rotation) {
+        if (!visible) return;
+        List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
+        int h = gp.getTileSize() * 6;
+        int visibleCount = (h - 40) / 40;
+        int maxOff = Math.max(0, skills.size() - visibleCount);
+        scrollOffset += rotation;
+        if (scrollOffset < 0) scrollOffset = 0;
+        if (scrollOffset > maxOff) scrollOffset = maxOff;
     }
 
     public void toggle() { visible = !visible; }

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -76,6 +76,14 @@ public class Ui {
         return hud.handleMousePress(mx, my, button);
     }
 
+    /** Xử lý cuộn chuột khi mở giao diện. */
+    public void handleMouseWheel(int rotation) {
+        inventory.handleMouseWheel(rotation);
+        if (skillUi.isVisible()) {
+            skillUi.handleMouseWheel(rotation);
+        }
+    }
+
     private void drawInteractionHint(Graphics2D g2) {
         List<Entity> nearbyNpcs = gp.getCheckCollision().getEntitiesInRange(gp.getPlayer(), gp.getNpcs(), 48);
         if (!nearbyNpcs.isEmpty()) {


### PR DESCRIPTION
## Summary
- show cooldown time in HUD and beside skills
- add scrollable skill list with Use/Assign buttons and hover info
- save learned skills to file and support mouse wheel in inventory

## Testing
- `javac -d bin $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68ac67648e08832f801a2663e2cfc569