### PR TITLE
Fix hover UI scaling and remove HUD cooldown text

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -18,3 +18,7 @@ Sửa lỗi và cải tiến:
 - Bảng công pháp chuyển sang bên phải, có nút **Dùng** và **Gán**, tooltip chi tiết và cuộn bằng con lăn.
 - Kho đồ hỗ trợ cuộn bằng con lăn chuột.
 - Hồ sơ .txt ghi thêm công pháp khi học mới.
+
+## 1.0.9
+- Fix HUD và bảng công pháp phóng to chữ khi hover item.
+- HUD bỏ hiển thị dòng "Hồi chiêu", chỉ còn tên và thời gian hiệu lực của đan dược/tu luyện.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@
 - Hồi chiêu công pháp hiển thị đầy đủ trong HUD và bảng công pháp.
 - Công pháp học mới được lưu vào tệp `.txt` ngay lập tức.
 
+## [1.0.9]
+
+### Sửa lỗi
+- Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
+- HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -71,12 +71,6 @@ public class GameHUD {
             g2.setColor(Color.WHITE);
             g2.drawString(text, x, infoY);
             infoY += 20;
-        } else if (p.getCultivationCooldownRemaining() > 0) {
-            long sec = p.getCultivationCooldownRemaining() / 1000;
-            String text = "Hồi chiêu: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
-            g2.setColor(Color.WHITE);
-            g2.drawString(text, x, infoY);
-            infoY += 20;
         }
 
         // Nếu đang tu luyện, vẽ nút hủy

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -39,7 +39,9 @@ public class InventoryUi {
     }
 
     public void draw(Graphics2D g2) {
-        int charH = gp.getTileSize() * 8;
+        Font oldFont = g2.getFont();
+        try {
+            int charH = gp.getTileSize() * 8;
         Dimension d = itemGrid.getPreferredSize();
         int gridX = gp.getTileSize() * 8; // default position with one tile gap after character panel
         int gridY = gp.getTileSize() * 2;
@@ -77,6 +79,9 @@ public class InventoryUi {
         }
 
         drawContextMenu(g2);
+        } finally {
+            g2.setFont(oldFont);
+        }
     }
 
     private int computeSlotIndex(int originX, int originY, Point mouse) {

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -1,6 +1,7 @@
 package game.ui;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -45,104 +46,109 @@ public class SkillUi {
     public void draw(Graphics2D g2) {
         if (!visible) return;
 
-        int tile = gp.getTileSize();
-        int w = tile * 8;
-        int h = tile * 6;
-        int x = gp.getScreenWidth() - w - tile; // dịch sang phải
-        int y = tile;
-        lastBounds.setBounds(x, y, w, h);
+        Font oldFont = g2.getFont();
+        try {
+            int tile = gp.getTileSize();
+            int w = tile * 8;
+            int h = tile * 6;
+            int x = gp.getScreenWidth() - w - tile; // dịch sang phải
+            int y = tile;
+            lastBounds.setBounds(x, y, w, h);
 
-        HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
+            HUDUtils.drawSubWindow(g2, x, y, w, h, new Color(0,0,0,200), Color.WHITE);
 
-        List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
-        int lineH = 40;
-        int visibleLines = Math.max(1, (h - 60) / lineH);
+            List<CultivationTechnique> skills = gp.getPlayer().getTechniques();
+            int lineH = 40;
+            int visibleLines = Math.max(1, (h - 60) / lineH);
 
-        // Giới hạn offset nằm trong [0, tổng - hiển thị]
-        int maxOffset = Math.max(0, skills.size() - visibleLines);
-        if (scrollOffset > maxOffset) scrollOffset = maxOffset;
-        if (scrollOffset < 0) scrollOffset = 0;
+            // Giới hạn offset nằm trong [0, tổng - hiển thị]
+            int maxOffset = Math.max(0, skills.size() - visibleLines);
+            if (scrollOffset > maxOffset) scrollOffset = maxOffset;
+            if (scrollOffset < 0) scrollOffset = 0;
 
-        entries = new Entry[skills.size()];
-        Point mouse = gp.getMousePosition();
-        hoverIndex = -1;
+            entries = new Entry[skills.size()];
+            Point mouse = gp.getMousePosition();
+            hoverIndex = -1;
 
-        for (int i = scrollOffset; i < skills.size() && i < scrollOffset + visibleLines; i++) {
-            CultivationTechnique tech = skills.get(i);
-            int idx = i - scrollOffset;
-            int yy = y + 40 + idx * lineH;
+            for (int i = scrollOffset; i < skills.size() && i < scrollOffset + visibleLines; i++) {
+                CultivationTechnique tech = skills.get(i);
+                int idx = i - scrollOffset;
+                int yy = y + 40 + idx * lineH;
 
-            Entry e = new Entry();
-            e.tech = tech;
-            e.area = new Rectangle(x + 20, yy - 25, w - 40, 30);
-            int btnW = 60, btnH = 25;
-            e.useBtn = new Rectangle(x + w - btnW*2 - 30, yy - 20, btnW, btnH);
-            e.assignBtn = new Rectangle(x + w - btnW - 15, yy - 20, btnW, btnH);
-            entries[i] = e;
+                Entry e = new Entry();
+                e.tech = tech;
+                e.area = new Rectangle(x + 20, yy - 25, w - 40, 30);
+                int btnW = 60, btnH = 25;
+                e.useBtn = new Rectangle(x + w - btnW*2 - 30, yy - 20, btnW, btnH);
+                e.assignBtn = new Rectangle(x + w - btnW - 15, yy - 20, btnW, btnH);
+                entries[i] = e;
 
-            // Highlight khi hover
-            if (mouse != null && e.area.contains(mouse)) {
-                hoverIndex = i;
-                g2.setColor(new Color(80,80,80,150));
-                g2.fill(e.area);
+                // Highlight khi hover
+                if (mouse != null && e.area.contains(mouse)) {
+                    hoverIndex = i;
+                    g2.setColor(new Color(80,80,80,150));
+                    g2.fill(e.area);
+                }
+
+                g2.setColor(Color.WHITE);
+                String name = tech.getName();
+                long cd = gp.getPlayer().getCultivationCooldownRemaining();
+                if (cd > 0) {
+                    long sec = cd / 1000;
+                    name += " (" + (sec/60) + ":" + String.format("%02d", sec%60) + ")";
+                }
+                g2.drawString(name, x + 30, yy);
+
+                // Vẽ nút "Sử dụng"
+                HUDUtils.drawSubWindow(g2, e.useBtn.x, e.useBtn.y, e.useBtn.width, e.useBtn.height,
+                        new Color(50,50,50,180), Color.WHITE);
+                g2.drawString("Dùng", e.useBtn.x + 12, e.useBtn.y + 18);
+
+                // Vẽ nút "Gán"
+                HUDUtils.drawSubWindow(g2, e.assignBtn.x, e.assignBtn.y, e.assignBtn.width, e.assignBtn.height,
+                        new Color(50,50,50,180), Color.WHITE);
+                g2.drawString("Gán", e.assignBtn.x + 15, e.assignBtn.y + 18);
             }
 
-            g2.setColor(Color.WHITE);
-            String name = tech.getName();
-            long cd = gp.getPlayer().getCultivationCooldownRemaining();
-            if (cd > 0) {
-                long sec = cd / 1000;
-                name += " (" + (sec/60) + ":" + String.format("%02d", sec%60) + ")";
+            // Thanh cuộn đơn giản
+            if (skills.size() > visibleLines) {
+                int trackH = h - 40;
+                int barH = Math.max(20, visibleLines * trackH / skills.size());
+                int barY = y + 20 + scrollOffset * (trackH - barH) / (skills.size() - visibleLines);
+                g2.setColor(new Color(120,120,120));
+                g2.fillRect(x + w - 15, y + 20, 8, trackH);
+                g2.setColor(Color.DARK_GRAY);
+                g2.fillRect(x + w - 15, barY, 8, barH);
             }
-            g2.drawString(name, x + 30, yy);
 
-            // Vẽ nút "Sử dụng"
-            HUDUtils.drawSubWindow(g2, e.useBtn.x, e.useBtn.y, e.useBtn.width, e.useBtn.height,
-                    new Color(50,50,50,180), Color.WHITE);
-            g2.drawString("Dùng", e.useBtn.x + 12, e.useBtn.y + 18);
+            // Tooltip khi hover
+            if (hoverIndex >= 0 && hoverIndex < skills.size()) {
+                CultivationTechnique tech = skills.get(hoverIndex);
+                String line1 = tech.getName();
+                String line2 = "Cấp: " + tech.getLevel();
+                String line3 = "Phẩm cấp: " + tech.getGrade().getDisplay();
+                long sec = gp.getPlayer().getCultivationCooldownRemaining() / 1000;
+                String line4 = "Hồi chiêu: " + (sec/60) + ":" + String.format("%02d", sec%60);
 
-            // Vẽ nút "Gán"
-            HUDUtils.drawSubWindow(g2, e.assignBtn.x, e.assignBtn.y, e.assignBtn.width, e.assignBtn.height,
-                    new Color(50,50,50,180), Color.WHITE);
-            g2.drawString("Gán", e.assignBtn.x + 15, e.assignBtn.y + 18);
-        }
-
-        // Thanh cuộn đơn giản
-        if (skills.size() > visibleLines) {
-            int trackH = h - 40;
-            int barH = Math.max(20, visibleLines * trackH / skills.size());
-            int barY = y + 20 + scrollOffset * (trackH - barH) / (skills.size() - visibleLines);
-            g2.setColor(new Color(120,120,120));
-            g2.fillRect(x + w - 15, y + 20, 8, trackH);
-            g2.setColor(Color.DARK_GRAY);
-            g2.fillRect(x + w - 15, barY, 8, barH);
-        }
-
-        // Tooltip khi hover
-        if (hoverIndex >= 0 && hoverIndex < skills.size()) {
-            CultivationTechnique tech = skills.get(hoverIndex);
-            String line1 = tech.getName();
-            String line2 = "Cấp: " + tech.getLevel();
-            String line3 = "Phẩm cấp: " + tech.getGrade().getDisplay();
-            long sec = gp.getPlayer().getCultivationCooldownRemaining() / 1000;
-            String line4 = "Hồi chiêu: " + (sec/60) + ":" + String.format("%02d", sec%60);
-
-            int padding = 10;
-            int width = Math.max(Math.max(g2.getFontMetrics().stringWidth(line1),
-                                         g2.getFontMetrics().stringWidth(line2)),
-                                 Math.max(g2.getFontMetrics().stringWidth(line3),
-                                          g2.getFontMetrics().stringWidth(line4))) + padding*2;
-            int height = 80 + padding*2;
-            int tipX = (mouse != null ? mouse.x + 15 : x + w + 10);
-            int tipY = (mouse != null ? mouse.y + 15 : y + 20);
-            if (tipX + width > gp.getScreenWidth()) tipX = gp.getScreenWidth() - width - 10;
-            if (tipY + height > gp.getScreenHeight()) tipY = gp.getScreenHeight() - height - 10;
-            HUDUtils.drawSubWindow(g2, tipX, tipY, width, height, new Color(40,40,40,200), Color.YELLOW);
-            g2.setColor(Color.WHITE);
-            g2.drawString(line1, tipX + padding, tipY + padding + 15);
-            g2.drawString(line2, tipX + padding, tipY + padding + 35);
-            g2.drawString(line3, tipX + padding, tipY + padding + 55);
-            g2.drawString(line4, tipX + padding, tipY + padding + 75);
+                int padding = 10;
+                int width = Math.max(Math.max(g2.getFontMetrics().stringWidth(line1),
+                                             g2.getFontMetrics().stringWidth(line2)),
+                                     Math.max(g2.getFontMetrics().stringWidth(line3),
+                                              g2.getFontMetrics().stringWidth(line4))) + padding*2;
+                int height = 80 + padding*2;
+                int tipX = (mouse != null ? mouse.x + 15 : x + w + 10);
+                int tipY = (mouse != null ? mouse.y + 15 : y + 20);
+                if (tipX + width > gp.getScreenWidth()) tipX = gp.getScreenWidth() - width - 10;
+                if (tipY + height > gp.getScreenHeight()) tipY = gp.getScreenHeight() - height - 10;
+                HUDUtils.drawSubWindow(g2, tipX, tipY, width, height, new Color(40,40,40,200), Color.YELLOW);
+                g2.setColor(Color.WHITE);
+                g2.drawString(line1, tipX + padding, tipY + padding + 15);
+                g2.drawString(line2, tipX + padding, tipY + padding + 35);
+                g2.drawString(line3, tipX + padding, tipY + padding + 55);
+                g2.drawString(line4, tipX + padding, tipY + padding + 75);
+            }
+        } finally {
+            g2.setFont(oldFont);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep HUD and skill window font size stable when hovering inventory items
- show only active pill or cultivation timer in HUD
- document fixes in Change.txt and README

## Testing
- `javac -d bin $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68ac72f79494832f844cea710dda0083