### PR TITLE
Fix HUD scaling and remove cooldown text

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -18,3 +18,8 @@ Sửa lỗi và cải tiến:
 - Bảng công pháp chuyển sang bên phải, có nút **Dùng** và **Gán**, tooltip chi tiết và cuộn bằng con lăn.
 - Kho đồ hỗ trợ cuộn bằng con lăn chuột.
 - Hồ sơ .txt ghi thêm công pháp khi học mới.
+
+## 1.0.9
+- Khắc phục lỗi HUD và chữ phóng to khi rê chuột qua item.
+- Giữ nguyên kích thước chữ khi hover trong bảng công pháp.
+- Loại bỏ dòng "Hồi chiêu" ở HUD, chỉ còn hiển thị hiệu ứng đang dùng.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@
 - Hồi chiêu công pháp hiển thị đầy đủ trong HUD và bảng công pháp.
 - Công pháp học mới được lưu vào tệp `.txt` ngay lập tức.
 
+## [1.0.9] - 2025-08-28
+
+### Sửa lỗi
+- Cố định kích thước HUD và chữ khi rê chuột vào item hoặc mở bảng công pháp.
+- Bỏ dòng "Hồi chiêu" trên HUD, chỉ giữ thông tin hiệu ứng đang sử dụng.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -1,8 +1,10 @@
 package game.ui;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.Stroke;
 import java.awt.event.MouseEvent;
 
 import game.entity.Player;
@@ -33,6 +35,10 @@ public class GameHUD {
 
     public void draw(Graphics2D g2) {
         Player p = gp.getPlayer();
+        Font oldFont = g2.getFont();
+        Stroke oldStroke = g2.getStroke();
+        Color oldColor = g2.getColor();
+        g2.setFont(oldFont.deriveFont(Font.PLAIN, 16f));
         int barWidth = gp.getTileSize() * 4;
         int barHeight = gp.getTileSize() / 3;
         int margin = 5;
@@ -71,12 +77,6 @@ public class GameHUD {
             g2.setColor(Color.WHITE);
             g2.drawString(text, x, infoY);
             infoY += 20;
-        } else if (p.getCultivationCooldownRemaining() > 0) {
-            long sec = p.getCultivationCooldownRemaining() / 1000;
-            String text = "Hồi chiêu: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
-            g2.setColor(Color.WHITE);
-            g2.drawString(text, x, infoY);
-            infoY += 20;
         }
 
         // Nếu đang tu luyện, vẽ nút hủy
@@ -86,6 +86,9 @@ public class GameHUD {
             g2.setColor(Color.WHITE);
             g2.drawString("Huỷ", cancelRect.x + 20, cancelRect.y + cancelRect.height - 10);
         }
+        g2.setFont(oldFont);
+        g2.setStroke(oldStroke);
+        g2.setColor(oldColor);
     }
 
     private void drawBar(Graphics2D g2, int x, int y, int w, int h,

--- a/src/game/ui/HUDUtils.java
+++ b/src/game/ui/HUDUtils.java
@@ -3,14 +3,21 @@ package game.ui;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Stroke;
 
 public final class HUDUtils {
 	private HUDUtils() {}
-	public static void drawSubWindow(Graphics2D g2, int x, int y, int w, int h, Color bg, Color border) {
-		g2.setColor(bg);
-		g2.fillRoundRect(x, y, w, h, 16, 16);
-		g2.setStroke(new BasicStroke(3f));
-		g2.setColor(border);
-		g2.drawRoundRect(x, y, w, h, 16, 16);
-	}
+        public static void drawSubWindow(Graphics2D g2, int x, int y, int w, int h, Color bg, Color border) {
+                Color oldColor = g2.getColor();
+                Stroke oldStroke = g2.getStroke();
+
+                g2.setColor(bg);
+                g2.fillRoundRect(x, y, w, h, 16, 16);
+                g2.setStroke(new BasicStroke(3f));
+                g2.setColor(border);
+                g2.drawRoundRect(x, y, w, h, 16, 16);
+
+                g2.setStroke(oldStroke);
+                g2.setColor(oldColor);
+        }
 }

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -39,6 +39,9 @@ public class InventoryUi {
     }
 
     public void draw(Graphics2D g2) {
+        var oldFont = g2.getFont();
+        var oldStroke = g2.getStroke();
+        var oldColor = g2.getColor();
         int charH = gp.getTileSize() * 8;
         Dimension d = itemGrid.getPreferredSize();
         int gridX = gp.getTileSize() * 8; // default position with one tile gap after character panel
@@ -77,6 +80,10 @@ public class InventoryUi {
         }
 
         drawContextMenu(g2);
+
+        g2.setFont(oldFont);
+        g2.setStroke(oldStroke);
+        g2.setColor(oldColor);
     }
 
     private int computeSlotIndex(int originX, int originY, Point mouse) {
@@ -168,22 +175,25 @@ public class InventoryUi {
 
     private void drawContextMenu(Graphics2D g2) {
         if (!contextVisible) return;
+        Font oldFont = g2.getFont();
         int w = 120;
         int h = contextOptions.length * 20 + 10;
         HUDUtils.drawSubWindow(g2, contextX, contextY, w, h, new Color(40,40,40,200), new Color(200, 200, 200));
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 16f));
+        g2.setFont(oldFont.deriveFont(Font.PLAIN, 16f));
         for (int i = 0; i < contextOptions.length; i++) {
             int yy = contextY + 20 + i * 20;
             g2.setColor(i == contextSelection ? Color.YELLOW : Color.WHITE);
             g2.drawString(contextOptions[i], contextX + 10, yy);
         }
+        g2.setFont(oldFont);
     }
 
     private void drawItemTooltip(Graphics2D g2, int x, int y, Item it) {
+        Font oldFont = g2.getFont();
         String line1 = it.getName() + " x" + it.getQuantity();
         String line2 = it.getDecription();
         int padding = 10;
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 16f));
+        g2.setFont(oldFont.deriveFont(Font.PLAIN, 16f));
         int width = Math.max(g2.getFontMetrics().stringWidth(line1), g2.getFontMetrics().stringWidth(line2)) + padding * 2;
         int height = 40 + padding * 2;
         if (x + width > gp.getScreenWidth()) {
@@ -196,6 +206,7 @@ public class InventoryUi {
         g2.setColor(Color.WHITE);
         g2.drawString(line1, x + padding, y + padding + 15);
         g2.drawString(line2, x + padding, y + padding + 35);
+        g2.setFont(oldFont);
     }
 
     /** Xử lý cuộn bằng con lăn chuột. */
@@ -220,12 +231,13 @@ public class InventoryUi {
      * @param topY starting Y position of the box
      */
     private void characterScreen(Graphics2D g2, int topY) {
+        Font oldFont = g2.getFont();
         int x = gp.getTileSize();
         int y = topY;
         int width = x * 5;
         int height = gp.getTileSize() * 6;
         drawSubWindow(x, y, width, height, g2);
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 12f));
+        g2.setFont(oldFont.deriveFont(Font.PLAIN, 12f));
         int textX = x + 10;
         int textY = y + 20;
 
@@ -252,9 +264,12 @@ public class InventoryUi {
         g2.setColor(Color.WHITE);
         g2.drawString("Công pháp", btnX + 10, btnY + btnH - 5);
         skillBtn.setBounds(btnX, btnY, btnW, btnH);
+        g2.setFont(oldFont);
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {
+        Color oldColor = g2.getColor();
+        var oldStroke = g2.getStroke();
         Color color = new Color(0, 0, 0, 210);
         g2.setColor(color);
         g2.fillRoundRect(x, y, width, height, 35, 35);
@@ -263,6 +278,9 @@ public class InventoryUi {
         g2.setColor(color);
         g2.setStroke(new BasicStroke(5));
         g2.drawRoundRect(x + 5, y + 5, width - 10, height - 10, 25, 25);
+
+        g2.setStroke(oldStroke);
+        g2.setColor(oldColor);
     }
 
     public boolean handleMousePress(int mx, int my, int button) {

--- a/src/game/ui/SkillUi.java
+++ b/src/game/ui/SkillUi.java
@@ -1,9 +1,11 @@
 package game.ui;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.Stroke;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
@@ -44,6 +46,11 @@ public class SkillUi {
      */
     public void draw(Graphics2D g2) {
         if (!visible) return;
+
+        var oldFont = g2.getFont();
+        var oldStroke = g2.getStroke();
+        var oldColor = g2.getColor();
+        g2.setFont(oldFont.deriveFont(Font.PLAIN, 16f));
 
         int tile = gp.getTileSize();
         int w = tile * 8;
@@ -144,6 +151,10 @@ public class SkillUi {
             g2.drawString(line3, tipX + padding, tipY + padding + 55);
             g2.drawString(line4, tipX + padding, tipY + padding + 75);
         }
+
+        g2.setFont(oldFont);
+        g2.setStroke(oldStroke);
+        g2.setColor(oldColor);
     }
 
     /**


### PR DESCRIPTION
## Summary
- restore Graphics2D font and stroke after drawing inventory, skill, and HUD widgets to keep sizes stable
- drop cultivation cooldown line from HUD, leaving only active effect info
- document fixes in Change.txt and README

## Testing
- `javac -d bin $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68ac72d7dbb4832fb8eb47427fb22110