### PR TITLE
Fix HUD scaling on hover and clean up cooldown display

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -18,3 +18,7 @@ Sửa lỗi và cải tiến:
 - Bảng công pháp chuyển sang bên phải, có nút **Dùng** và **Gán**, tooltip chi tiết và cuộn bằng con lăn.
 - Kho đồ hỗ trợ cuộn bằng con lăn chuột.
 - Hồ sơ .txt ghi thêm công pháp khi học mới.
+
+## 1.0.9
+- Sửa lỗi HUD và chữ bị phóng to khi rê chuột vào item.
+- Loại bỏ dòng "Hồi chiêu" khỏi HUD, chỉ giữ thông tin hiệu ứng đang dùng.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@
 - Hồi chiêu công pháp hiển thị đầy đủ trong HUD và bảng công pháp.
 - Công pháp học mới được lưu vào tệp `.txt` ngay lập tức.
 
+## [1.0.9] - 2025-08-28
+
+### Sửa lỗi
+- HUD và chữ không còn phóng to khi rê chuột vào item.
+
+### Thay đổi
+- HUD bỏ hiển thị dòng "Hồi chiêu", chỉ giữ thông tin hiệu ứng đang sử dụng.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/ui/GameHUD.java
+++ b/src/game/ui/GameHUD.java
@@ -71,12 +71,6 @@ public class GameHUD {
             g2.setColor(Color.WHITE);
             g2.drawString(text, x, infoY);
             infoY += 20;
-        } else if (p.getCultivationCooldownRemaining() > 0) {
-            long sec = p.getCultivationCooldownRemaining() / 1000;
-            String text = "Hồi chiêu: " + (sec / 60) + ":" + String.format("%02d", sec % 60);
-            g2.setColor(Color.WHITE);
-            g2.drawString(text, x, infoY);
-            infoY += 20;
         }
 
         // Nếu đang tu luyện, vẽ nút hủy

--- a/src/game/ui/HUDUtils.java
+++ b/src/game/ui/HUDUtils.java
@@ -3,14 +3,17 @@ package game.ui;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Stroke;
 
 public final class HUDUtils {
 	private HUDUtils() {}
-	public static void drawSubWindow(Graphics2D g2, int x, int y, int w, int h, Color bg, Color border) {
-		g2.setColor(bg);
-		g2.fillRoundRect(x, y, w, h, 16, 16);
-		g2.setStroke(new BasicStroke(3f));
-		g2.setColor(border);
-		g2.drawRoundRect(x, y, w, h, 16, 16);
-	}
+        public static void drawSubWindow(Graphics2D g2, int x, int y, int w, int h, Color bg, Color border) {
+                g2.setColor(bg);
+                g2.fillRoundRect(x, y, w, h, 16, 16);
+                Stroke old = g2.getStroke();
+                g2.setStroke(new BasicStroke(3f));
+                g2.setColor(border);
+                g2.drawRoundRect(x, y, w, h, 16, 16);
+                g2.setStroke(old);
+        }
 }

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -6,6 +6,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.Stroke;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
@@ -39,6 +40,10 @@ public class InventoryUi {
     }
 
     public void draw(Graphics2D g2) {
+        Font oldFont = g2.getFont();
+        Stroke oldStroke = g2.getStroke();
+        Color oldColor = g2.getColor();
+
         int charH = gp.getTileSize() * 8;
         Dimension d = itemGrid.getPreferredSize();
         int gridX = gp.getTileSize() * 8; // default position with one tile gap after character panel
@@ -77,6 +82,10 @@ public class InventoryUi {
         }
 
         drawContextMenu(g2);
+
+        g2.setFont(oldFont);
+        g2.setStroke(oldStroke);
+        g2.setColor(oldColor);
     }
 
     private int computeSlotIndex(int originX, int originY, Point mouse) {
@@ -171,19 +180,22 @@ public class InventoryUi {
         int w = 120;
         int h = contextOptions.length * 20 + 10;
         HUDUtils.drawSubWindow(g2, contextX, contextY, w, h, new Color(40,40,40,200), new Color(200, 200, 200));
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 16f));
+        Font old = g2.getFont();
+        g2.setFont(old.deriveFont(Font.PLAIN, 16f));
         for (int i = 0; i < contextOptions.length; i++) {
             int yy = contextY + 20 + i * 20;
             g2.setColor(i == contextSelection ? Color.YELLOW : Color.WHITE);
             g2.drawString(contextOptions[i], contextX + 10, yy);
         }
+        g2.setFont(old);
     }
 
     private void drawItemTooltip(Graphics2D g2, int x, int y, Item it) {
         String line1 = it.getName() + " x" + it.getQuantity();
         String line2 = it.getDecription();
         int padding = 10;
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 16f));
+        Font old = g2.getFont();
+        g2.setFont(old.deriveFont(Font.PLAIN, 16f));
         int width = Math.max(g2.getFontMetrics().stringWidth(line1), g2.getFontMetrics().stringWidth(line2)) + padding * 2;
         int height = 40 + padding * 2;
         if (x + width > gp.getScreenWidth()) {
@@ -196,6 +208,7 @@ public class InventoryUi {
         g2.setColor(Color.WHITE);
         g2.drawString(line1, x + padding, y + padding + 15);
         g2.drawString(line2, x + padding, y + padding + 35);
+        g2.setFont(old);
     }
 
     /** Xử lý cuộn bằng con lăn chuột. */
@@ -224,8 +237,9 @@ public class InventoryUi {
         int y = topY;
         int width = x * 5;
         int height = gp.getTileSize() * 6;
+        Font oldFont = g2.getFont();
         drawSubWindow(x, y, width, height, g2);
-        g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 12f));
+        g2.setFont(oldFont.deriveFont(Font.PLAIN, 12f));
         int textX = x + 10;
         int textY = y + 20;
 
@@ -252,6 +266,7 @@ public class InventoryUi {
         g2.setColor(Color.WHITE);
         g2.drawString("Công pháp", btnX + 10, btnY + btnH - 5);
         skillBtn.setBounds(btnX, btnY, btnW, btnH);
+        g2.setFont(oldFont);
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {
@@ -261,8 +276,10 @@ public class InventoryUi {
 
         color = new Color(255, 255, 255);
         g2.setColor(color);
+        Stroke old = g2.getStroke();
         g2.setStroke(new BasicStroke(5));
         g2.drawRoundRect(x + 5, y + 5, width - 10, height - 10, 25, 25);
+        g2.setStroke(old);
     }
 
     public boolean handleMousePress(int mx, int my, int button) {

--- a/src/game/ui/ItemGridUi.java
+++ b/src/game/ui/ItemGridUi.java
@@ -6,6 +6,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Stroke;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
@@ -44,6 +45,8 @@ public class ItemGridUi {
                      int selected, int hover, int offset) {
         int total = (items == null) ? 0 : items.size();
         Dimension d = getPreferredSize();
+        Font oldFont = g2.getFont();
+        Stroke oldStroke = g2.getStroke();
 
         // Khung lớn
         HUDUtils.drawSubWindow(g2, x, y, d.width, d.height,
@@ -84,11 +87,11 @@ public class ItemGridUi {
                     g2.setStroke(new BasicStroke(3f));
                     g2.drawRoundRect(xx, yy, slotSize, slotSize, 10, 10);
                 }
-                g2.setStroke(new BasicStroke(1f));
+                g2.setStroke(oldStroke);
 
                 if (it != null) {
                     String q = String.valueOf(it.getQuantity());
-                    g2.setFont(g2.getFont().deriveFont(Font.BOLD, 12f));
+                    g2.setFont(oldFont.deriveFont(Font.BOLD, 12f));
                     FontMetrics fm = g2.getFontMetrics();
                     int tw = fm.stringWidth(q), th = fm.getAscent();
                     int boxX = xx + slotSize - tw - 8;
@@ -115,6 +118,8 @@ public class ItemGridUi {
             g2.setColor(new Color(255,255,255,150));
             g2.fillRect(barX, barY, 3, barH);
         }
+        g2.setFont(oldFont);
+        g2.setStroke(oldStroke);
     }
 
     public int getCols() { return cols; }


### PR DESCRIPTION
## Summary
- Prevent inventory UI from altering global font/stroke so HUD no longer scales when hovering items
- Remove cooldown text from HUD, leaving only active effect timers
- Document changes in Change.txt and README

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ac72c44738832f867fafa1a8492a5b