### PR TITLE
Fix Tiên Linh Thể speed and profile text format

### DIFF
--- a/AI_Changes.txt
+++ b/AI_Changes.txt
@@ -1,0 +1,3 @@
+- Sửa lỗi thể chất Tiên Linh Thể không tăng tốc tu luyện gấp 3 lần.
+- Định dạng lại tệp lưu thuộc tính HEALTH/PEP/SPIRIT theo dạng hiện tại/tổng.
+- Cập nhật README.md và Change.txt.

--- a/Change.txt
+++ b/Change.txt
@@ -23,3 +23,7 @@ Sửa lỗi và cải tiến:
 ## 1.0.9
 - Fix HUD và bảng công pháp phóng to chữ khi hover item.
 - HUD bỏ hiển thị dòng "Hồi chiêu", chỉ còn tên và thời gian hiệu lực của đan dược/tu luyện.
+
+## 1.0.10
+- Sửa lỗi thể chất Tiên Linh Thể không tăng tốc tu luyện gấp 3 lần.
+- Tệp lưu thuộc tính định dạng HEALTH, PEP, SPIRIT dạng "hiện tại/tổng".

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@
 - Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
 - HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
 
+## [1.0.10]
+
+### Sửa lỗi
+- Sửa lỗi thể chất **Tiên Linh Thể** không tăng tốc tu luyện gấp 3 lần.
+- Định dạng tệp lưu thuộc tính HEALTH/PEP/SPIRIT thành "hiện tại/tối đa" để khởi động game đọc đúng dữ liệu.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -478,7 +478,10 @@ public class Player extends GameActor implements DrawableEntity {
         }
         if (now - lastSpiritTick >= 1000) {
             lastSpiritTick += 1000;
-            gainSpirit(activeTechnique.getSpiritPerSecond() + pillSpiritBonus);
+            // Tốc độ tu luyện chịu ảnh hưởng bởi thể chất
+            int base = activeTechnique.getSpiritPerSecond() + pillSpiritBonus;
+            int amount = (int) Math.round(base * physique.getCultivationSpeed());
+            gainSpirit(amount);
         }
     }
 
@@ -629,12 +632,15 @@ public class Player extends GameActor implements DrawableEntity {
         StringBuilder sb = new StringBuilder();
         sb.append("=============================\n");
         sb.append("cảnh giới " + getRealmName().toLowerCase() + " - " + time + "\n");
-        sb.append("HEALTH: " + atts().getMax(Attr.HEALTH) + "\n");
+        // Ghi lại máu hiện tại/tối đa
+        sb.append("HEALTH: " + atts().get(Attr.HEALTH) + "/" + atts().getMax(Attr.HEALTH) + "\n");
         sb.append("ATTACK: " + atts().get(Attr.ATTACK) + "\n");
-        sb.append("PEP: " + atts().getMax(Attr.PEP) + "\n");
+        // Ghi lại PEP hiện tại/tối đa
+        sb.append("PEP: " + atts().get(Attr.PEP) + "/" + atts().getMax(Attr.PEP) + "\n");
         sb.append("DEF: " + atts().get(Attr.DEF) + "\n");
         sb.append("SOULD: " + atts().get(Attr.SOULD) + "\n");
-        sb.append("SPIRIT " + spiritToNextLevel + "\n");
+        // Ghi lại SPIRIT hiện có/tổng yêu cầu
+        sb.append("SPIRIT: " + atts().get(Attr.SPIRIT) + "/" + spiritToNextLevel + "\n");
         sb.append("STRENGTH: " + atts().get(Attr.STRENGTH) + "\n");
         sb.append("PHYSIQUE: " + physique.getDisplay() + "\n");
         sb.append("AFFINITY: " + getAffinityNames() + "\n");
@@ -738,26 +744,33 @@ public class Player extends GameActor implements DrawableEntity {
             for (int i = 2; i < block.size(); i++) {
                 String line = block.get(i);
                 if (line.startsWith("HEALTH: ")) {
-                    int v = Integer.parseInt(line.substring(8).trim());
-                    atts().setMax(Attr.HEALTH, v);
-                    atts().set(Attr.HEALTH, v);
+                    String[] vals = line.substring(8).trim().split("/");
+                    int current = Integer.parseInt(vals[0].trim());
+                    int max = (vals.length > 1) ? Integer.parseInt(vals[1].trim()) : current;
+                    atts().setMax(Attr.HEALTH, max);
+                    atts().set(Attr.HEALTH, current);
                 } else if (line.startsWith("ATTACK: ")) {
                     int v = Integer.parseInt(line.substring(8).trim());
                     atts().set(Attr.ATTACK, v);
                 } else if (line.startsWith("PEP: ")) {
-                    int v = Integer.parseInt(line.substring(5).trim());
-                    atts().setMax(Attr.PEP, v);
-                    atts().set(Attr.PEP, v);
+                    String[] vals = line.substring(5).trim().split("/");
+                    int current = Integer.parseInt(vals[0].trim());
+                    int max = (vals.length > 1) ? Integer.parseInt(vals[1].trim()) : current;
+                    atts().setMax(Attr.PEP, max);
+                    atts().set(Attr.PEP, current);
                 } else if (line.startsWith("DEF: ")) {
                     int v = Integer.parseInt(line.substring(5).trim());
                     atts().set(Attr.DEF, v);
                 } else if (line.startsWith("SOULD: ")) {
                     int v = Integer.parseInt(line.substring(7).trim());
                     atts().set(Attr.SOULD, v);
-                } else if (line.startsWith("SPIRIT ")) {
-                    spiritToNextLevel = Integer.parseInt(line.substring(7).trim());
-                    atts().setMax(Attr.SPIRIT, spiritToNextLevel);
-                    atts().set(Attr.SPIRIT, 0);
+                } else if (line.startsWith("SPIRIT: ")) {
+                    String[] vals = line.substring(8).trim().split("/");
+                    int current = Integer.parseInt(vals[0].trim());
+                    int total = (vals.length > 1) ? Integer.parseInt(vals[1].trim()) : current;
+                    spiritToNextLevel = total;
+                    atts().setMax(Attr.SPIRIT, total);
+                    atts().set(Attr.SPIRIT, current);
                 } else if (line.startsWith("STRENGTH: ")) {
                     int v = Integer.parseInt(line.substring(10).trim());
                     atts().set(Attr.STRENGTH, v);

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -5,28 +5,32 @@ package game.enums;
  * Một số thể chất ảnh hưởng đến số tầng tối đa hoặc chỉ số khi lên cấp.
  */
 public enum Physique {
-    NORMAL("Bình thường", 10, 1.0, 1.0, 1.0),
-    HU_KHONG("Hư không", 15, 1.0, 1.0, 1.0),
-    HU_KHONG_DAI_DE("Hư không đại đế", 20, 1.0, 1.0, 1.0),
-    THANH_THE("Thánh Thể", 10, 1.0, 2.0, 1.0),
-    TIEN_LINH_THE("Tiên Linh Thể", 10, 1.0/3.0, 1.0, 1.0),
-    THAN_THE("Thần Thể", 10, 1.0, 1.0, 1.0),
+    NORMAL("Bình thường", 10, 1.0, 1.0, 1.0, 1.0),
+    HU_KHONG("Hư không", 15, 1.0, 1.0, 1.0, 1.0),
+    HU_KHONG_DAI_DE("Hư không đại đế", 20, 1.0, 1.0, 1.0, 1.0),
+    THANH_THE("Thánh Thể", 10, 1.0, 2.0, 1.0, 1.0),
+    // Tiên Linh Thể giảm yêu cầu SPIRIT và tăng tốc tu luyện gấp 3
+    TIEN_LINH_THE("Tiên Linh Thể", 10, 1.0/3.0, 1.0, 1.0, 3.0),
+    THAN_THE("Thần Thể", 10, 1.0, 1.0, 1.0, 1.0),
     // Ngũ Hành: chỉ số gấp 2 lần nên yêu cầu SPIRIT gấp 3
-    NGU_HANH("Ngũ Hành Linh Căn", 10, 2.0, 1.0, 3.0);
+    NGU_HANH("Ngũ Hành Linh Căn", 10, 2.0, 1.0, 3.0, 1.0);
 
     private final String display;
     private final int maxStage;
     private final double spiritReqFactor;
     private final double defFactor;
     private final double statFactor;
+    /** Hệ số tốc độ tu luyện (1 = bình thường) */
+    private final double cultivationSpeed;
 
     Physique(String display, int maxStage, double spiritReqFactor,
-             double defFactor, double statFactor) {
+             double defFactor, double statFactor, double cultivationSpeed) {
         this.display = display;
         this.maxStage = maxStage;
         this.spiritReqFactor = spiritReqFactor;
         this.defFactor = defFactor;
         this.statFactor = statFactor;
+        this.cultivationSpeed = cultivationSpeed;
     }
 
     /** @return tên hiển thị của thể chất */
@@ -39,4 +43,6 @@ public enum Physique {
     public double getDefFactor() { return defFactor; }
     /** @return hệ số cộng dồn cho toàn bộ chỉ số */
     public double getStatFactor() { return statFactor; }
+    /** @return hệ số tăng tốc tu luyện */
+    public double getCultivationSpeed() { return cultivationSpeed; }
 }


### PR DESCRIPTION
## Summary
- Triple cultivation speed for Tiên Linh Thể physique
- Log HEALTH/PEP/SPIRIT as current/total in player profile
- Update documentation and changelog

## Testing
- `javac -d bin $(find src -name "*.java") && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68ac7a5706f8832fa7b30d891f4d6a4e