### PR TITLE
Fix Tiên Linh Thể spirit requirement

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -35,4 +35,12 @@ Sửa lỗi và cải tiến:
 	   - Cập nhật cả phần ghi (`logRealmState`) và đọc (`loadProfile`).
 	   - Cập nhật ví dụ tệp `player.Nguyeen_pro.20250825.txt`.
 	
-	3. Cập nhật README với mô tả thay đổi.
+        3. Cập nhật README với mô tả thay đổi.
+
+## 1.0.11
+        1. Sửa lỗi Tiên Linh Thể:
+           - `spiritReqFactor` đặt về 1.0 để tránh giảm tổng SPIRIT khi thăng cấp.
+           - Thêm kiểm tra yêu cầu SPIRIT tối thiểu và vòng lặp `gainSpirit` tránh lặp vô hạn.
+        2. Hồ sơ người chơi thiếu dòng `PHYSIQUE` mặc định về "Bình thường".
+        3. Điều chỉnh Ngũ Hành Linh Căn: chỉ số x2, yêu cầu SPIRIT x3.
+        4. Cập nhật README.md mô tả thay đổi.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@
 - Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
 - HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
 
+## [1.0.11]
+
+### Sửa lỗi
+- Thể chất **Tiên Linh Thể** không còn làm giảm yêu cầu SPIRIT và gây dừng tu luyện sau Luyện khí tầng 10.
+- Tệp lưu thiếu dòng `PHYSIQUE` mặc định về "Bình thường" để tránh lỗi khi mở bảng item.
+
+### Thay đổi
+- Điều chỉnh **Ngũ Hành Linh Căn**: chỉ số x2, yêu cầu SPIRIT x3.
+- `gainSpirit` và `levelUp` kiểm tra yêu cầu SPIRIT tối thiểu để tránh vòng lặp vô hạn.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -120,7 +120,7 @@ public class Player extends GameActor implements DrawableEntity {
             affinities = randomAffinities();
 
             // Ngũ Hành Linh Căn có chỉ số gấp 5 lần nên yêu cầu SPIRIT cũng gấp 5
-            spiritToNextLevel = (int) (spiritToNextLevel * physique.getSpiritReqFactor());
+            spiritToNextLevel = Math.max(1, (int) (spiritToNextLevel * physique.getSpiritReqFactor()));
             atts().setMax(Attr.SPIRIT, spiritToNextLevel);
 
             // Thêm vài item test: bình hồi máu & tinh thần
@@ -416,7 +416,7 @@ public class Player extends GameActor implements DrawableEntity {
         // Tiên Linh Thể tu luyện nhanh gấp 3 lần
         int modified = (int) Math.round(amount * physique.getCultivationSpeedFactor());
         atts().add(Attr.SPIRIT, modified);
-        while (atts().get(Attr.SPIRIT) >= spiritToNextLevel) {
+        while (spiritToNextLevel > 0 && atts().get(Attr.SPIRIT) >= spiritToNextLevel) {
             atts().add(Attr.SPIRIT, -spiritToNextLevel);
             levelUp();
         }
@@ -538,6 +538,7 @@ public class Player extends GameActor implements DrawableEntity {
                 }
             }
         }
+        spiritToNextLevel = Math.max(1, spiritToNextLevel);
         // Cập nhật max Spirit cho HUD
         atts().setMax(Attr.SPIRIT, spiritToNextLevel);
         logRealmState();
@@ -624,6 +625,7 @@ public class Player extends GameActor implements DrawableEntity {
         atts().set(Attr.SOULD, soul);
 
         spiritToNextLevel = (int) (oldReq * 2 * physique.getSpiritReqFactor());
+        spiritToNextLevel = Math.max(1, spiritToNextLevel);
     }
 
     private void logRealmState() {
@@ -827,6 +829,9 @@ public class Player extends GameActor implements DrawableEntity {
                 }
             }
 
+            if (physique == null) {
+                physique = Physique.NORMAL;
+            }
             return true;
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/game/enums/Physique.java
+++ b/src/game/enums/Physique.java
@@ -10,10 +10,10 @@ public enum Physique {
     HU_KHONG_DAI_DE("Hư không đại đế", 20, 1.0, 1.0, 1.0, 1.0),
     THANH_THE("Thánh Thể", 10, 1.0, 2.0, 1.0, 1.0),
     // Tiên Linh Thể: tu luyện nhanh gấp 3 lần
-    TIEN_LINH_THE("Tiên Linh Thể", 10, 1.0/3.0, 1.0, 1.0, 3.0),
+    TIEN_LINH_THE("Tiên Linh Thể", 10, 1.0, 1.0, 1.0, 3.0),
     THAN_THE("Thần Thể", 10, 1.0, 1.0, 1.0, 1.0),
     // Ngũ Hành: chỉ số gấp 2 lần nên yêu cầu SPIRIT gấp 3
-    NGU_HANH("Ngũ Hành Linh Căn", 10, 2.0, 1.0, 3.0, 1.0);
+    NGU_HANH("Ngũ Hành Linh Căn", 10, 3.0, 1.0, 2.0, 1.0);
 
     private final String display;
     private final int maxStage;


### PR DESCRIPTION
## Summary
- Prevent spirit requirement from shrinking when leveling Tiên Linh Thể
- Guard against missing PHYSIQUE in save files and zero spirit requirements
- Document fixes in README and Change log

## Testing
- `javac -d bin $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68ac83288f98832fb16763712a096c1f