### PR TITLE
Fix spirit requirement and physique loading

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -35,4 +35,9 @@ Sửa lỗi và cải tiến:
 	   - Cập nhật cả phần ghi (`logRealmState`) và đọc (`loadProfile`).
 	   - Cập nhật ví dụ tệp `player.Nguyeen_pro.20250825.txt`.
 	
-	3. Cập nhật README với mô tả thay đổi.
+        3. Cập nhật README với mô tả thay đổi.
+
+## 1.0.11
+- Khắc phục lỗi SPIRIT trở về 0/0 khi đạt Luyện khí tầng 10 khiến không thể tu luyện tiếp.
+- Đảm bảo `physique` và `affinity` luôn có giá trị hợp lệ khi đọc tệp lưu để tránh lỗi bảng thuộc tính.
+- Thêm kiểm tra trong `gainSpirit` để bỏ qua khi yêu cầu SPIRIT không hợp lệ.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@
 - Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
 - HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
 
+## [1.0.11] - 2025-08-27
+
+### Sửa lỗi
+- SPIRIT không còn trở về 0/0 khi đạt Luyện khí tầng 10.
+- Sửa lỗi mở bảng item/thuộc tính gây NullPointerException khi thiếu thông tin thể chất.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi


### PR DESCRIPTION
## Summary
- Prevent SPIRIT from resetting to 0 at max Luyện khí stage
- Safeguard physique/affinity loading to avoid NPE in inventory screen
- Document fixes in README and Change log

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ac832bd5b4832fa2a7db78950efb8e