### PR TITLE
Fix Spirit scaling and inventory physique crash

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -35,4 +35,9 @@ Sửa lỗi và cải tiến:
 	   - Cập nhật cả phần ghi (`logRealmState`) và đọc (`loadProfile`).
 	   - Cập nhật ví dụ tệp `player.Nguyeen_pro.20250825.txt`.
 	
-	3. Cập nhật README với mô tả thay đổi.
+        3. Cập nhật README với mô tả thay đổi.
+
+## 1.0.11
+- Sửa công thức tăng yêu cầu Spirit để không giảm khi lên cấp, đặc biệt cho Tiên Linh Thể.
+- Đạt giới hạn tầng Luyện khí không còn làm Spirit trở về 0 và vẫn tích luỹ được.
+- Bảng item/thuộc tính xử lý trường hợp thiếu dữ liệu thể chất tránh lỗi NullPointerException.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@
 - Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
 - HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
 
+## [1.0.11]
+
+### Sửa lỗi
+- Yêu cầu **Spirit** tăng đúng sau khi lên cấp, không còn giảm với thể chất *Tiên Linh Thể*.
+- Đạt Luyện khí tầng 10 vẫn có thể tiếp tục tích luỹ Spirit thay vì bị đặt về 0/0.
+- Mở bảng item/thuộc tính không còn lỗi khi hồ sơ thiếu thông tin thể chất.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -145,6 +145,8 @@ public class Player extends GameActor implements DrawableEntity {
             saveProfile();
         }
 
+        if (physique == null) physique = Physique.NORMAL;
+
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
         }
@@ -416,7 +418,14 @@ public class Player extends GameActor implements DrawableEntity {
         // Tiên Linh Thể tu luyện nhanh gấp 3 lần
         int modified = (int) Math.round(amount * physique.getCultivationSpeedFactor());
         atts().add(Attr.SPIRIT, modified);
+
         while (atts().get(Attr.SPIRIT) >= spiritToNextLevel) {
+            // Đã đạt tầng tối đa của đại cảnh giới hiện tại
+            if (realm == Realm.LUYEN_KHI && realmStage >= physique.getMaxStage()) {
+                atts().set(Attr.SPIRIT, spiritToNextLevel); // giữ nguyên ở mức tối đa
+                break;
+            }
+
             atts().add(Attr.SPIRIT, -spiritToNextLevel);
             levelUp();
         }
@@ -515,7 +524,7 @@ public class Player extends GameActor implements DrawableEntity {
                 realm = Realm.LUYEN_THE;
                 realmStage = 1;
                 initializeLuyenThe();
-                spiritToNextLevel = (int) ((oldReq + oldReq / 2) * physique.getSpiritReqFactor());
+                spiritToNextLevel = oldReq + (int) (oldReq / 2 * physique.getSpiritReqFactor());
                 atts().add(Attr.SOULD, 10);
             }
             case LUYEN_THE -> {
@@ -525,7 +534,7 @@ public class Player extends GameActor implements DrawableEntity {
                     atts().add(Attr.SOULD, 10);
                 } else {
                     applyStageGrowth();
-                    spiritToNextLevel = (int) ((oldReq + oldReq / 2) * physique.getSpiritReqFactor());
+                    spiritToNextLevel = oldReq + (int) (oldReq / 2 * physique.getSpiritReqFactor());
                 }
             }
             case LUYEN_KHI -> {
@@ -534,7 +543,7 @@ public class Player extends GameActor implements DrawableEntity {
                     realmStage = physique.getMaxStage();
                 } else {
                     applyStageGrowth();
-                    spiritToNextLevel = (int) ((oldReq + oldReq / 2) * physique.getSpiritReqFactor());
+                    spiritToNextLevel = oldReq + (int) (oldReq / 2 * physique.getSpiritReqFactor());
                 }
             }
         }
@@ -623,7 +632,8 @@ public class Player extends GameActor implements DrawableEntity {
         int soul = (int) (atts().get(Attr.SOULD) * 2 * physique.getStatFactor());
         atts().set(Attr.SOULD, soul);
 
-        spiritToNextLevel = (int) (oldReq * 2 * physique.getSpiritReqFactor());
+        // Yêu cầu SPIRIT mới tăng dựa trên hệ số của thể chất nhưng luôn lớn hơn cấp trước
+        spiritToNextLevel = oldReq + (int) (oldReq * physique.getSpiritReqFactor());
     }
 
     private void logRealmState() {
@@ -740,8 +750,8 @@ public class Player extends GameActor implements DrawableEntity {
                 if (idx >= 0) realmStage = Integer.parseInt(lower.substring(idx + 4).trim());
             }
 
-            for (int i = 2; i < block.size(); i++) {
-                String line = block.get(i);
+        for (int i = 2; i < block.size(); i++) {
+            String line = block.get(i);
                 if (line.startsWith("HEALTH: ")) {
                     String val = line.substring(8).trim();
                     int cur, max;
@@ -824,15 +834,15 @@ public class Player extends GameActor implements DrawableEntity {
                             techniques.add(new CultivationTechnique(name, grade, lvl, sps));
                         }
                     }
-                }
             }
-
-            return true;
-        } catch (IOException e) {
-            e.printStackTrace();
-            return false;
         }
+        if (physique == null) physique = Physique.NORMAL;
+        return true;
+    } catch (IOException e) {
+        e.printStackTrace();
+        return false;
     }
+}
 
     private Path findExistingProfile() throws IOException {
         String safeName = getName().replaceAll("\\s+", "_");

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -245,7 +245,8 @@ public class InventoryUi {
         g2.drawString("Def: " + attrs.get(Attr.DEF), textX, textY); textY += 15;
         g2.drawString("Strength: " + attrs.get(Attr.STRENGTH), textX, textY); textY += 15;
         g2.drawString("Sould: " + attrs.get(Attr.SOULD), textX, textY); textY += 15;
-        g2.drawString("Physique: " + p.getPhysique().getDisplay(), textX, textY); textY += 15;
+        String phys = (p.getPhysique() != null) ? p.getPhysique().getDisplay() : "Unknown";
+        g2.drawString("Physique: " + phys, textX, textY); textY += 15;
         g2.drawString("Affinity: " + p.getAffinityNames(), textX, textY); textY += 20;
 
         // Vẽ nút mở bảng công pháp


### PR DESCRIPTION
## Summary
- Ensure Spirit requirement increases properly and cap Spirit after reaching Luyện khí max level
- Default missing Physique to NORMAL and guard inventory display to avoid null pointer
- Document fixes in README and Change log

## Testing
- `javac -d bin @sources.list`


------
https://chatgpt.com/codex/tasks/task_e_68ac832d70b0832f8f6bf0a75ff0f415