### PR TITLE
feat: add periodic autosave and save on exit

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -42,3 +42,8 @@ Sửa lỗi và cải tiến:
 - Đảm bảo `Physique` luôn có giá trị hợp lệ và bảng thuộc tính không bị lỗi khi mở.
 - Tải hồ sơ sẽ tự tính lại yêu cầu SPIRIT nếu tệp lưu chứa giá trị không hợp lệ.
 - bug: sử dụng đan dược tăng SPIRIT x nhân 3 yêu cầu tăng như bình thường
+
+## 1.0.12
+- Thêm cơ chế tự lưu mỗi 10 phút và khi thoát game.
+- Đảm bảo HEALTH, PEP và SPIRIT còn lại được ghi vào tệp lưu.
+- Cập nhật README mô tả thay đổi.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@
 - Yêu cầu SPIRIT không còn giảm dần theo cấp và sẽ tự tính lại nếu tệp lưu có giá trị 0.
 - Bảng thuộc tính không còn lỗi NullPointerException khi mở.
 
+## [1.0.12]
+
+### Thêm
+- Tự động lưu trạng thái mỗi 10 phút và khi thoát game.
+
+### Sửa lỗi
+- Đảm bảo HEALTH, PEP và SPIRIT còn lại được ghi vào tệp lưu.
+
 ## [1.0.6] - 2025-08-25
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -79,6 +79,10 @@ public class Player extends GameActor implements DrawableEntity {
     private LocalDate creationDate = LocalDate.now();
     private final List<String> realmLog = new ArrayList<>();
 
+    // Tự động lưu
+    private long lastAutoSave = System.currentTimeMillis();
+    private static final long AUTO_SAVE_INTERVAL = 10 * 60 * 1000; // 10 phút
+
     // Danh sách công pháp đã học
     private final List<CultivationTechnique> techniques = new ArrayList<>();
     // Trạng thái tu luyện
@@ -201,6 +205,12 @@ public class Player extends GameActor implements DrawableEntity {
             }
             updateKeyboard();
             handleAttack();
+
+            long now = System.currentTimeMillis();
+            if (now - lastAutoSave >= AUTO_SAVE_INTERVAL) {
+                saveState();
+                lastAutoSave = now;
+            }
         }
 
 	
@@ -658,6 +668,12 @@ public class Player extends GameActor implements DrawableEntity {
         sb.append("AFFINITY: " + getAffinityNames() + "\n");
         sb.append("SKILL: " + getSkillSummary() + "\n");
         realmLog.add(sb.toString());
+    }
+
+    /** Lưu trạng thái hiện tại vào tệp. */
+    public void saveState() {
+        logRealmState();
+        saveProfile();
     }
 
     private void saveProfile() {

--- a/src/game/main/MainGame.java
+++ b/src/game/main/MainGame.java
@@ -1,19 +1,27 @@
 package game.main;
 
 import javax.swing.JFrame;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 public class MainGame {
 	public static void main(String[] args) {
-		JFrame window = new JFrame("Game");
-		window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		window.setResizable(true);
-		window.setTitle("Game demo");
-		GamePanel game = new GamePanel();
-		window.add(game);
-		window.pack(); // Use the JPanel component to determine window configuration
-		window.setLocationRelativeTo(null);
-		window.setVisible(true);
-	    game.setUpGame();
-		game.startGame();
-	}
+                JFrame window = new JFrame("Game");
+                window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                window.setResizable(true);
+                window.setTitle("Game demo");
+                GamePanel game = new GamePanel();
+                window.add(game);
+                window.addWindowListener(new WindowAdapter() {
+                    @Override
+                    public void windowClosing(WindowEvent e) {
+                        game.getPlayer().saveState();
+                    }
+                });
+                window.pack(); // Use the JPanel component to determine window configuration
+                window.setLocationRelativeTo(null);
+                window.setVisible(true);
+            game.setUpGame();
+                game.startGame();
+        }
 }


### PR DESCRIPTION
## Summary
- Save player health, pep, and spirit by logging current stats before each save
- Autosave every 10 minutes via timer inside player update loop
- Save player state when closing the game window

## Testing
- `find src -name "*.java" > sources.list`
- `javac -d bin @sources.list`


------
https://chatgpt.com/codex/tasks/task_e_68ad353e90ec832fb4aca55f3dacbd9a