### PR TITLE
Implement periodic and exit autosaves for player stats

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -42,3 +42,8 @@ Sửa lỗi và cải tiến:
 - Đảm bảo `Physique` luôn có giá trị hợp lệ và bảng thuộc tính không bị lỗi khi mở.
 - Tải hồ sơ sẽ tự tính lại yêu cầu SPIRIT nếu tệp lưu chứa giá trị không hợp lệ.
 - bug: sử dụng đan dược tăng SPIRIT x nhân 3 yêu cầu tăng như bình thường
+
+## 1.0.12
+- Tự động lưu hồ sơ mỗi 10 phút và khi thoát game.
+- Sửa lỗi không ghi lại chỉ số HEALTH/PEP/SPIRIT còn lại vào tệp lưu.
+- Cập nhật README mô tả cơ chế tự lưu.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@
 - Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
 - HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
 
+## [1.0.12]
+
+### Thêm
+- Tự động lưu hồ sơ mỗi 10 phút và trước khi thoát game.
+
+### Sửa lỗi
+- Ghi lại chính xác lượng HEALTH/PEP/SPIRIT còn lại trong tệp lưu.
+
 ## [1.0.11]
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -23,6 +23,10 @@ import java.util.stream.Collectors;
 
 import javax.imageio.ImageIO;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import game.entity.inventory.Inventory;
 import game.entity.item.Item;
 import game.interfaces.DrawableEntity;
@@ -79,6 +83,13 @@ public class Player extends GameActor implements DrawableEntity {
     private LocalDate creationDate = LocalDate.now();
     private final List<String> realmLog = new ArrayList<>();
 
+    // Tự động lưu hồ sơ
+    private final ScheduledExecutorService autoSaveExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r);
+        t.setDaemon(true);
+        return t;
+    });
+
     // Danh sách công pháp đã học
     private final List<CultivationTechnique> techniques = new ArrayList<>();
     // Trạng thái tu luyện
@@ -101,6 +112,7 @@ public class Player extends GameActor implements DrawableEntity {
         getImagePlayer();
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
 
+        startAutoSave();
         }
         public void setDefaultValue() {
                 setWorldX(100);
@@ -151,8 +163,7 @@ public class Player extends GameActor implements DrawableEntity {
             addItem(new game.entity.item.elixir.CultivationPill("Đan thượng phẩm", 3, 1));
             addItem(new game.entity.item.elixir.CultivationPill("Đan cực phẩm", 4, 1));
 
-            logRealmState();
-            saveProfile();
+            saveState();
         }
 
         setScaleEntityX(gp.getTileSize());
@@ -416,7 +427,7 @@ public class Player extends GameActor implements DrawableEntity {
     public void useItem(Item i) {
         i.use(this);
         if(i.getQuantity() == 0) bag.remove(i);
-        saveProfile();
+        saveState();
     }
 
     /**
@@ -439,8 +450,7 @@ public class Player extends GameActor implements DrawableEntity {
         techniques.add(tech);
         // Lưu lại tiến trình ngay sau khi học để đảm bảo
         // công pháp tồn tại khi thoát game.
-        logRealmState();
-        saveProfile();
+        saveState();
     }
 
     // Công pháp được gán vào phím nhanh (tạm thời lưu 1 kỹ năng).
@@ -552,8 +562,7 @@ public class Player extends GameActor implements DrawableEntity {
         }
         // Cập nhật max Spirit cho HUD
         atts().setMax(Attr.SPIRIT, spiritToNextLevel);
-        logRealmState();
-        saveProfile();
+        saveState();
     }
 
     /**
@@ -658,6 +667,20 @@ public class Player extends GameActor implements DrawableEntity {
         sb.append("AFFINITY: " + getAffinityNames() + "\n");
         sb.append("SKILL: " + getSkillSummary() + "\n");
         realmLog.add(sb.toString());
+    }
+
+    public synchronized void saveState() {
+        logRealmState();
+        saveProfile();
+    }
+
+    private void startAutoSave() {
+        autoSaveExecutor.scheduleAtFixedRate(this::saveState, 10, 10, TimeUnit.MINUTES);
+    }
+
+    public void stopAutoSave() {
+        autoSaveExecutor.shutdownNow();
+        saveState();
     }
 
     private void saveProfile() {

--- a/src/game/main/MainGame.java
+++ b/src/game/main/MainGame.java
@@ -11,9 +11,13 @@ public class MainGame {
 		GamePanel game = new GamePanel();
 		window.add(game);
 		window.pack(); // Use the JPanel component to determine window configuration
-		window.setLocationRelativeTo(null);
-		window.setVisible(true);
-	    game.setUpGame();
-		game.startGame();
-	}
+                window.setLocationRelativeTo(null);
+                window.setVisible(true);
+            game.setUpGame();
+                game.startGame();
+
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    game.getPlayer().stopAutoSave();
+                }));
+        }
 }


### PR DESCRIPTION
## Summary
- ensure player stats (HEALTH/PEP/SPIRIT) are logged before saving
- add scheduled auto-save every 10 minutes and when the game closes
- document new auto-save behavior in README and Change log

## Testing
- `find src -name "*.java" > sources.txt`
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ad354b6b84832f84cbb28a8e9ec757