### PR TITLE
Fix cultivation cooldown behavior

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -47,3 +47,7 @@ Sửa lỗi và cải tiến:
 - Tự động lưu hồ sơ mỗi 10 phút và khi thoát game.
 - Sửa lỗi không ghi lại chỉ số HEALTH/PEP/SPIRIT còn lại vào tệp lưu.
 - Cập nhật README mô tả cơ chế tự lưu.
+
+## 1.0.13
+- Sửa lỗi có thể nhấp tu luyện nhiều lần để kéo dài thời gian.
+- Hồi chiêu tu luyện bắt đầu khi bắt đầu tu luyện và kéo dài 2 giờ.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@
 - Khi rê chuột vào item, HUD và khung công pháp không còn bị phóng to chữ.
 - HUD chỉ hiển thị tên và thời gian hiệu lực của đan dược hoặc tu luyện, bỏ dòng hồi chiêu.
 
+## [1.0.13]
+
+### Sửa lỗi
+- Không còn có thể nhấp tu luyện nhiều lần để kéo dài thời gian.
+- Hồi chiêu tu luyện bắt đầu ngay khi tu luyện và kéo dài 2 giờ.
+
 ## [1.0.12]
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -474,16 +474,17 @@ public class Player extends GameActor implements DrawableEntity {
 
     public void startCultivating(CultivationTechnique tech) {
         long now = System.currentTimeMillis();
-        if (now < cultivationCooldownEnd) return;
+        if (cultivating || now < cultivationCooldownEnd) return;
         cultivating = true;
         activeTechnique = tech;
         lastSpiritTick = now;
         cultivationEndTime = now + 3600_000L;
+        cultivationCooldownEnd = now + 7200_000L; // 2h cooldown starts immediately
     }
 
     public void cancelCultivation() {
         cultivating = false;
-        cultivationCooldownEnd = System.currentTimeMillis() + 3600_000L; // 1h
+        activeTechnique = null;
     }
 
     private void updateCultivation() {
@@ -495,7 +496,7 @@ public class Player extends GameActor implements DrawableEntity {
         if (!cultivating) return;
         if (now >= cultivationEndTime) {
             cultivating = false;
-            cultivationCooldownEnd = now + 3600_000L;
+            activeTechnique = null;
             return;
         }
         if (now - lastSpiritTick >= 1000) {


### PR DESCRIPTION
## Summary
- prevent stacking cultivation sessions
- start cultivation cooldown immediately and extend to two hours
- document cultivation cooldown changes

## Testing
- `find src -name "*.java" > sources.list`
- `javac -d bin @sources.list`


------
https://chatgpt.com/codex/tasks/task_e_68ad450ddeb0832f828a850f569b342c