### PR TITLE
Fix cultivation cooldown to prevent stacking

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -2,7 +2,7 @@ Cập nhật:
 - Thêm hệ thống kỹ năng cơ bản và lớp Skill.
 - Tạo công pháp tu luyện 4 phẩm cấp cùng sách học tương ứng.
 - Thêm đan dược tăng tốc tu luyện 4 phẩm cấp, hiệu lực 10 phút.
-- Nhân vật có thể tu luyện, kèm nút Huỷ và thời gian hồi chiêu 1 giờ.
+- Nhân vật có thể tu luyện, kèm nút Huỷ và thời gian hồi chiêu 2 giờ.
 - HUD hiển thị buff đan dược và nút hủy khi đang tu luyện.
 - Bảng thuộc tính có nút mở danh sách công pháp.
 - Định dạng file lưu tiến trình bổ sung dòng SKILL.
@@ -47,3 +47,8 @@ Sửa lỗi và cải tiến:
 - Tự động lưu hồ sơ mỗi 10 phút và khi thoát game.
 - Sửa lỗi không ghi lại chỉ số HEALTH/PEP/SPIRIT còn lại vào tệp lưu.
 - Cập nhật README mô tả cơ chế tự lưu.
+
+## 1.0.13
+- Sửa lỗi có thể nhấn tu luyện nhiều lần để kéo dài thời gian.
+- Hồi chiêu tu luyện bắt đầu từ lúc tu luyện và kéo dài 2 giờ.
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Hệ thống **Kỹ năng** cơ bản với class `Skill` dễ mở rộng.
 - 4 công pháp tu luyện (hạ, trung, thượng, cực phẩm) học qua sách.
 - 4 loại đan dược tăng tốc tu luyện, cộng thêm SPIRIT mỗi giây trong 10 phút.
-- Tu luyện đứng im, có nút **Huỷ** ở HUD và hồi chiêu 1 giờ.
+- Tu luyện đứng im, có nút **Huỷ** ở HUD và hồi chiêu 2 giờ.
 - HUD hiển thị tên đan dược đang dùng và thời gian đếm ngược.
 - Bảng thuộc tính có nút mở danh sách công pháp.
 - Tệp lưu người chơi thêm mục `SKILL` ghi lại công pháp đã học.
@@ -54,6 +54,11 @@
 
 ### Sửa lỗi
 - Ghi lại chính xác lượng HEALTH/PEP/SPIRIT còn lại trong tệp lưu.
+
+## [1.0.13]
+
+### Sửa lỗi
+- Tu luyện không còn được kích hoạt liên tiếp để kéo dài thời gian. Hồi chiêu bắt đầu từ lúc tu luyện và kéo dài 2 giờ.
 
 ## [1.0.11]
 

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -93,6 +93,8 @@ public class Player extends GameActor implements DrawableEntity {
     // Danh sách công pháp đã học
     private final List<CultivationTechnique> techniques = new ArrayList<>();
     // Trạng thái tu luyện
+    private static final long CULTIVATION_DURATION = 3600_000L;
+    private static final long CULTIVATION_COOLDOWN = 7200_000L;
     private boolean cultivating = false;
     private CultivationTechnique activeTechnique;
     private long cultivationEndTime = 0;
@@ -474,16 +476,16 @@ public class Player extends GameActor implements DrawableEntity {
 
     public void startCultivating(CultivationTechnique tech) {
         long now = System.currentTimeMillis();
-        if (now < cultivationCooldownEnd) return;
+        if (cultivating || now < cultivationCooldownEnd) return;
         cultivating = true;
         activeTechnique = tech;
         lastSpiritTick = now;
-        cultivationEndTime = now + 3600_000L;
+        cultivationEndTime = now + CULTIVATION_DURATION;
+        cultivationCooldownEnd = now + CULTIVATION_COOLDOWN;
     }
 
     public void cancelCultivation() {
         cultivating = false;
-        cultivationCooldownEnd = System.currentTimeMillis() + 3600_000L; // 1h
     }
 
     private void updateCultivation() {
@@ -495,7 +497,6 @@ public class Player extends GameActor implements DrawableEntity {
         if (!cultivating) return;
         if (now >= cultivationEndTime) {
             cultivating = false;
-            cultivationCooldownEnd = now + 3600_000L;
             return;
         }
         if (now - lastSpiritTick >= 1000) {


### PR DESCRIPTION
## Summary
- prevent stacking cultivation sessions by starting cooldown when training begins
- set cultivation cooldown to 2 hours
- document cooldown changes in README and Change.txt

## Testing
- `javac -d /tmp/out -cp src @sources.list`


------
https://chatgpt.com/codex/tasks/task_e_68ad450b432c832f9fa6c6353fef0ba2