### PR TITLE
feat: add equipment UI and item drops

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -52,3 +52,10 @@ Sửa lỗi và cải tiến:
 - Bug: phát hiện lỗi khi đang tu luyện nhấp vào tu luyện lần nữa thì vẫn có thể tu luyện thêm một tiếng
 - Sửa lỗi có thể nhấp tu luyện nhiều lần để kéo dài thời gian.
 - Hồi chiêu tu luyện bắt đầu khi bắt đầu tu luyện và kéo dài 2 giờ.
+
+## 1.0.14
+- Thêm khung trang bị và hình ảnh nhân vật trong kho đồ.
+- Kho đồ mặc định 30 ô, nhẫn tăng thêm 10 ô; ô trống hiển thị màu trắng.
+- Trang bị đúng ô sẽ cộng chỉ số, nhấn phải vào ô trang bị để tháo.
+- Vật phẩm khi Drop rơi ra đất; quái rơi vật phẩm 100% và tự xoá sau 2 phút.
+- Bảng thuộc tính chuyển xuống dưới khung item.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 ## Cập nhật
 
+## [1.0.14]
+
+### Thêm
+- Khung trang bị với 10 ô, hiển thị hình nhân vật và cho phép đeo/tháo trang bị.
+- Trang bị cộng chỉ số (mũ/áo/quần/giày +3 DEF, kiếm +10 ATTACK, dây chuyền +10 SOULD, nhẫn +10 ô chứa).
+- Kho đồ mặc định 30 ô và có thể mở rộng bằng nhẫn; ô trống hiển thị màu trắng và cuộn ngay cả khi chưa đầy.
+- Quái rơi vật phẩm trên đất 100% và có thể nhặt bằng chuột, vật rơi tự xoá sau 2 phút.
+
+### Thay đổi
+- Bỏ vật phẩm trong kho sẽ rơi ra đất quanh người chơi thay vì biến mất.
+- Bảng thuộc tính chuyển xuống dưới khung item với chiều rộng tương ứng.
+
 ## [1.0.13]
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -19,6 +19,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.EnumMap;
 import java.util.stream.Collectors;
 
 import javax.imageio.ImageIO;
@@ -29,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 
 import game.entity.inventory.Inventory;
 import game.entity.item.Item;
+import game.entity.item.equipment.Equipment;
+import game.entity.item.equipment.SimpleEquipment;
 import game.interfaces.DrawableEntity;
 import game.entity.monster.Monster;
 import game.enums.Affinity;
@@ -36,6 +39,7 @@ import game.enums.Attr;
 import game.enums.Physique;
 import game.enums.Realm;
 import game.enums.SkillGrade;
+import game.enums.EquipSlot;
 import game.entity.skill.CultivationTechnique;
 
 import game.main.GamePanel;
@@ -50,6 +54,7 @@ public class Player extends GameActor implements DrawableEntity {
     private static final int INTERACTION_RANGE = 80;
 
     private final Inventory bag = new Inventory();
+    private final EnumMap<EquipSlot, Equipment> equips = new EnumMap<>(EquipSlot.class);
     private boolean invincible = false;
     private int invincibleCounter = 0;
     private final Rectangle attackArea;
@@ -134,6 +139,12 @@ public class Player extends GameActor implements DrawableEntity {
             atts().set(Attr.DEF, 4);
             atts().set(Attr.STRENGTH, 1);
             atts().set(Attr.SOULD, 5);
+
+            bag.add(new SimpleEquipment("Helmet", "", EquipSlot.HELMET, 0, 3, 0, 0, Color.GRAY));
+            bag.add(new SimpleEquipment("Armor", "", EquipSlot.ARMOR, 0, 3, 0, 0, Color.BLUE));
+            bag.add(new SimpleEquipment("Boots", "", EquipSlot.BOOTS, 0, 3, 0, 0, Color.ORANGE));
+            bag.add(new SimpleEquipment("Sword", "", EquipSlot.WEAPON1, 10, 0, 0, 0, Color.RED));
+            bag.add(new SimpleEquipment("Ring", "", EquipSlot.RING1, 0, 0, 0, 10, Color.GREEN));
 
             // Thiết lập thể chất và linh căn ngẫu nhiên
             physique = randomPhysique();
@@ -1016,4 +1027,34 @@ public class Player extends GameActor implements DrawableEntity {
 
     public static int getInteractionRange() { return INTERACTION_RANGE; }
     public Inventory getBag() { return bag; }
+
+    public EnumMap<EquipSlot, Equipment> getEquips() { return equips; }
+
+    public void equip(Equipment e) {
+        EquipSlot slot = e.getSlot();
+        Equipment old = equips.get(slot);
+        if (old != null) {
+            old.onUnequip(this);
+            bag.add(old);
+        }
+        equips.put(slot, e);
+        e.onEquip(this);
+    }
+
+    public void unequip(EquipSlot slot) {
+        Equipment old = equips.remove(slot);
+        if (old != null) {
+            bag.add(old);
+            old.onUnequip(this);
+        }
+    }
+
+    public void dropItem(Item it) {
+        int dx = random.nextInt(41) - 20;
+        int dy = random.nextInt(41) - 20;
+        game.object.DroppedItem obj = new game.object.DroppedItem(it);
+        obj.setWorldX(getWorldX() + dx);
+        obj.setWorldY(getWorldY() + dy);
+        gp.getObjects().add(obj);
+    }
 }

--- a/src/game/entity/inventory/Inventory.java
+++ b/src/game/entity/inventory/Inventory.java
@@ -6,7 +6,8 @@ import java.util.List;
 import game.entity.item.Item;
 
 public class Inventory {
-	private final List<Item> items = new ArrayList<Item>();
+        private final List<Item> items = new ArrayList<Item>();
+        private int capacity = 30;
 	
     // Thêm item có cộng dồn + tràn ô (stacking)
     public void add(Item incoming) {
@@ -26,7 +27,7 @@ public class Inventory {
         }
 
         // Tạo thêm các stack mới cho phần còn lại (chia theo maxStack)
-        while (remain > 0) {
+        while (remain > 0 && items.size() < capacity) {
             int chunk = Math.min(incoming.getMaxStack(), remain);
             Item piece = incoming.copyWithQuantity(chunk);
             items.add(piece);
@@ -40,6 +41,11 @@ public class Inventory {
         public List<Item> all(){
                 return List.copyOf(items);
         }
+
+    public int getCapacity() { return capacity; }
+    public void setCapacity(int capacity) { this.capacity = capacity; }
+
+    public boolean isFull() { return items.size() >= capacity; }
 
     public void clear() {
         items.clear();

--- a/src/game/entity/item/Item.java
+++ b/src/game/entity/item/Item.java
@@ -52,6 +52,9 @@ public abstract class Item {
                 p.getBag().remove(this);
             }
         } else if ("Drop".equalsIgnoreCase(action)) {
+            // Rớt vật phẩm ra ngoài bản đồ
+            Item dropped = copyWithQuantity(getQuantity());
+            p.dropItem(dropped);
             p.getBag().remove(this);
         }
     }

--- a/src/game/entity/item/equipment/Equipment.java
+++ b/src/game/entity/item/equipment/Equipment.java
@@ -1,0 +1,73 @@
+package game.entity.item.equipment;
+
+import java.awt.image.BufferedImage;
+
+import game.entity.Player;
+import game.entity.item.Item;
+import game.enums.Attr;
+import game.enums.EquipSlot;
+
+/**
+ * Item trang bị cơ bản với các thuộc tính cộng thêm.
+ */
+public abstract class Equipment extends Item {
+    private final EquipSlot slot;
+    private final int atkBonus;
+    private final int defBonus;
+    private final int soulBonus;
+    private final int bagBonus;
+
+    public Equipment(String name, String desc, EquipSlot slot,
+                     int atk, int def, int soul, int bagBonus) {
+        super(name, desc, 1, 1); // trang bị không cộng dồn
+        this.slot = slot;
+        this.atkBonus = atk;
+        this.defBonus = def;
+        this.soulBonus = soul;
+        this.bagBonus = bagBonus;
+    }
+
+    public EquipSlot getSlot() { return slot; }
+
+    public void onEquip(Player p) {
+        if (atkBonus != 0) p.atts().add(Attr.ATTACK, atkBonus);
+        if (defBonus != 0) p.atts().add(Attr.DEF, defBonus);
+        if (soulBonus != 0) p.atts().add(Attr.SOULD, soulBonus);
+        if (bagBonus != 0) p.getBag().setCapacity(p.getBag().getCapacity() + bagBonus);
+    }
+
+    public void onUnequip(Player p) {
+        if (atkBonus != 0) p.atts().add(Attr.ATTACK, -atkBonus);
+        if (defBonus != 0) p.atts().add(Attr.DEF, -defBonus);
+        if (soulBonus != 0) p.atts().add(Attr.SOULD, -soulBonus);
+        if (bagBonus != 0) p.getBag().setCapacity(Math.max(30, p.getBag().getCapacity() - bagBonus));
+    }
+
+    @Override
+    public void use(Player p) {
+        p.getBag().remove(this);
+        p.equip(this);
+    }
+
+    @Override
+    public String[] getActions() {
+        return new String[] {"Use", "Drop"};
+    }
+
+    @Override
+    public void performAction(Player p, String action) {
+        if ("Use".equalsIgnoreCase(action)) {
+            use(p);
+        } else if ("Drop".equalsIgnoreCase(action)) {
+            p.dropItem(this);
+        }
+    }
+
+    @Override
+    public abstract BufferedImage getIcon();
+
+    @Override
+    public Equipment copyWithQuantity(int qty) {
+        return this; // không cộng dồn nên trả về chính nó
+    }
+}

--- a/src/game/entity/item/equipment/SimpleEquipment.java
+++ b/src/game/entity/item/equipment/SimpleEquipment.java
@@ -1,0 +1,31 @@
+package game.entity.item.equipment;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import game.enums.EquipSlot;
+
+/**
+ * Trang bị đơn giản dùng màu sắc minh họa.
+ */
+public class SimpleEquipment extends Equipment {
+    private final BufferedImage icon;
+
+    public SimpleEquipment(String name, String desc, EquipSlot slot,
+                           int atk, int def, int soul, int bagBonus, Color color) {
+        super(name, desc, slot, atk, def, soul, bagBonus);
+        this.icon = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = icon.createGraphics();
+        g.setColor(color);
+        g.fillRect(0, 0, 32, 32);
+        g.setColor(Color.BLACK);
+        g.drawRect(0, 0, 31, 31);
+        g.dispose();
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -316,7 +316,13 @@ public abstract class Monster extends GameActor {
      */
     public void dropItem() {
         if (random.nextInt(100) < getDropChance()) {
-        	 gp.getPlayer().addItem(new game.entity.item.elixir.HealthPotion(30, 1));
+            game.entity.item.Item loot = new game.entity.item.elixir.HealthPotion(30, 1);
+            int dx = random.nextInt(41) - 20;
+            int dy = random.nextInt(41) - 20;
+            game.object.DroppedItem obj = new game.object.DroppedItem(loot);
+            obj.setWorldX(getWorldX() + dx);
+            obj.setWorldY(getWorldY() + dy);
+            gp.getObjects().add(obj);
         }
     }
 

--- a/src/game/enums/EquipSlot.java
+++ b/src/game/enums/EquipSlot.java
@@ -1,0 +1,17 @@
+package game.enums;
+
+/**
+ * Các vị trí trang bị của nhân vật.
+ */
+public enum EquipSlot {
+    HELMET,     // 1 - mũ
+    ARMOR,      // 2 - áo
+    BOOTS,      // 3 - giày
+    PANTS,      // 4 - quần
+    NECKLACE,   // 5 - dây chuyền
+    TALISMAN,   // 6 - pháp khí hộ thể
+    RING1,      // 7 - nhẫn 1
+    RING2,      // 8 - nhẫn 2
+    WEAPON1,    // 9 - vũ khí 1
+    WEAPON2;    // 10 - vũ khí 2
+}

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -117,7 +117,7 @@ public class GamePanel extends JPanel implements Runnable {
 	}
 	
 	public void update() {
-		if(gameState == playState) {
+                if(gameState == playState) {
                     player.update();
                     for (MonsterZone zone : monsterZones) {
                         zone.update();
@@ -131,6 +131,8 @@ public class GamePanel extends JPanel implements Runnable {
                             m.update();
                         }
                     }
+                    long now = System.currentTimeMillis();
+                    objects.removeIf(o -> o instanceof game.object.DroppedItem di && now - di.getSpawnTime() > 120_000);
                 }
                 if(gameState == pauseState) {}
         }

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -4,6 +4,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
+import java.awt.Rectangle;
 
 import game.main.GamePanel;
 
@@ -19,14 +20,39 @@ public class MouseHandler implements MouseListener, MouseWheelListener {
     public void mouseClicked(MouseEvent e) { }
     @Override
     public void mousePressed(MouseEvent e) {
-    	// Ưu tiên xử lý click cho UI (kho đồ, nút hủy, bảng công pháp...)
+        // Ưu tiên xử lý click cho UI (kho đồ, nút hủy, bảng công pháp...)
         if (gp.getUi().handleInventoryMousePress(e.getX(), e.getY(), e.getButton())) {
             return;
         }
         if (gp.keyH.isiPressed()) {
             return;
         }
-            // Right mouse pressed
+
+        if (e.getButton() == MouseEvent.BUTTON1) {
+            int mouseX = e.getX();
+            int mouseY = e.getY();
+            int worldX = gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() + mouseX;
+            int worldY = gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() + mouseY;
+            for (int i = 0; i < gp.getObjects().size(); i++) {
+                var obj = gp.getObjects().get(i);
+                if (obj instanceof game.object.DroppedItem di) {
+                    Rectangle r = di.getCollisionArea();
+                    int ox = di.getWorldX();
+                    int oy = di.getWorldY();
+                    if (worldX >= ox + r.x && worldX <= ox + r.x + r.width &&
+                        worldY >= oy + r.y && worldY <= oy + r.y + r.height) {
+                        if (!gp.getPlayer().getBag().isFull()) {
+                            gp.getPlayer().getBag().add(di.getItem());
+                            gp.getObjects().remove(i);
+                        } else {
+                            gp.getUi().showMessage("Kho vật phẩm đầy");
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+        // Right mouse pressed
         if (e.getButton() == MouseEvent.BUTTON3) {
             //Tọa độ x,y trên màn hình
             int mouseX = e.getX();

--- a/src/game/object/DroppedItem.java
+++ b/src/game/object/DroppedItem.java
@@ -1,0 +1,23 @@
+package game.object;
+
+import java.awt.Rectangle;
+
+import game.entity.item.Item;
+
+/**
+ * Vật phẩm nằm trên đất sau khi rơi ra.
+ */
+public class DroppedItem extends SuperObject {
+    private final Item item;
+    private final long spawnTime = System.currentTimeMillis();
+
+    public DroppedItem(Item it) {
+        this.item = it;
+        setName(it.getName());
+        setImage(it.getIcon());
+        setCollisionArea(new Rectangle(0, 0, 32, 32));
+    }
+
+    public Item getItem() { return item; }
+    public long getSpawnTime() { return spawnTime; }
+}

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -6,11 +6,14 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.util.List;
 
 import game.entity.item.Item;
+import game.entity.item.equipment.Equipment;
 import game.enums.Attr;
+import game.enums.EquipSlot;
 import game.main.GamePanel;
 
 /**
@@ -32,6 +35,13 @@ public class InventoryUi {
     private int contextSelection = 0;
     private int contextX, contextY;
     private java.awt.Rectangle skillBtn = new java.awt.Rectangle();
+    private Rectangle[] equipSlots = new Rectangle[EquipSlot.values().length];
+    private int equipHover = -1;
+    private static final EquipSlot[] SLOT_ORDER = {
+        EquipSlot.HELMET, EquipSlot.ARMOR, EquipSlot.BOOTS,
+        EquipSlot.PANTS, EquipSlot.NECKLACE, EquipSlot.TALISMAN,
+        EquipSlot.RING1, EquipSlot.RING2, EquipSlot.WEAPON1, EquipSlot.WEAPON2
+    };
 
     public InventoryUi(GamePanel gp) {
         this.gp = gp;
@@ -41,34 +51,32 @@ public class InventoryUi {
     public void draw(Graphics2D g2) {
         Font oldFont = g2.getFont();
         try {
-            int charH = gp.getTileSize() * 8;
         Dimension d = itemGrid.getPreferredSize();
-        int gridX = gp.getTileSize() * 8; // default position with one tile gap after character panel
+        int gridX = gp.getTileSize() * 8;
         int gridY = gp.getTileSize() * 2;
-        // ensure grid within screen
         if (gridX + d.width > gp.getScreenWidth() - gp.getTileSize() / 2) {
             gridX = gp.getScreenWidth() - d.width - gp.getTileSize() / 2;
         }
 
+        int attrH = gp.getTileSize() * 6;
         int outerX = gp.getTileSize() / 2;
-        int outerY = gridY - gp.getTileSize() / 2; // keep margin similar to original
+        int outerY = gridY - gp.getTileSize() / 2;
         int outerW = gridX + d.width + gp.getTileSize() / 2 - outerX;
-        int outerH = Math.max(charH, d.height) + gp.getTileSize();
-        lastGridX = gridX;
-        lastGridY = gridY;
-        lastDim.setSize(d);
+        int outerH = d.height + attrH + gp.getTileSize();
         HUDUtils.drawSubWindow(g2, outerX, outerY, outerW, outerH,
                 new Color(40,40,40,180), Color.YELLOW);
 
-        // Draw character panel on the left
-        characterScreen(g2, gridY);
+        drawEquipmentPanel(g2, gp.getTileSize(), gridY);
 
         var items = gp.getPlayer().getBag().all();
         handleInventoryInput(items, gridX, gridY);
         int hoverLocal = computeSlotIndex(gridX, gridY, gp.getMousePosition());
         hoverSlot = (hoverLocal >= 0) ? scrollOffset + hoverLocal : -1;
-
-        itemGrid.draw(g2, gridX, gridY, items, selectedSlot, hoverSlot, scrollOffset);
+        int capacity = gp.getPlayer().getBag().getCapacity();
+        lastGridX = gridX;
+        lastGridY = gridY;
+        lastDim.setSize(d);
+        itemGrid.draw(g2, gridX, gridY, items, selectedSlot, hoverSlot, scrollOffset, capacity);
 
         int infoIdx = hoverSlot;
         if (infoIdx >= 0 && infoIdx < items.size()) {
@@ -77,6 +85,20 @@ public class InventoryUi {
             int tipY = (m != null ? m.y + 15 : gridY);
             drawItemTooltip(g2, tipX, tipY, items.get(infoIdx));
         }
+
+        if (equipHover >= 0) {
+            Equipment eq = gp.getPlayer().getEquips().get(SLOT_ORDER[equipHover]);
+            if (eq != null) {
+                Point m = gp.getMousePosition();
+                int tipX = (m != null ? m.x + 15 : gridX);
+                int tipY = (m != null ? m.y + 15 : gridY);
+                drawItemTooltip(g2, tipX, tipY, eq);
+            }
+        }
+
+        int attrX = gridX;
+        int attrY = gridY + d.height + gp.getTileSize() / 2;
+        drawAttributePanel(g2, attrX, attrY, d.width, attrH);
 
         drawContextMenu(g2);
         } finally {
@@ -135,7 +157,7 @@ public class InventoryUi {
         if (kh.isLeftPressed()) { selectedSlot--; kh.setLeftPressed(false); }
         if (kh.isRightPressed()) { selectedSlot++; kh.setRightPressed(false); }
 
-        int maxIndex = Math.max(0, items.size() - 1);
+        int maxIndex = Math.max(0, gp.getPlayer().getBag().getCapacity() - 1);
         if (selectedSlot < 0) selectedSlot = 0;
         if (selectedSlot > maxIndex) selectedSlot = maxIndex;
 
@@ -145,7 +167,7 @@ public class InventoryUi {
         } else if (selectedSlot >= scrollOffset + visible) {
             scrollOffset = (selectedSlot / cols - rows + 1) * cols;
         }
-        int maxOffset = Math.max(0, items.size() - visible);
+        int maxOffset = Math.max(0, gp.getPlayer().getBag().getCapacity() - visible);
         if (scrollOffset > maxOffset) scrollOffset = maxOffset;
         if (scrollOffset < 0) scrollOffset = 0;
 
@@ -212,7 +234,7 @@ public class InventoryUi {
         int cols = itemGrid.getCols();
         int rows = itemGrid.getRows();
         int visible = cols * rows;
-        int total = gp.getPlayer().getBag().all().size();
+        int total = gp.getPlayer().getBag().getCapacity();
         int maxOffset = Math.max(0, total - visible);
         scrollOffset += Integer.signum(rotation) * cols;
         if (scrollOffset < 0) scrollOffset = 0;
@@ -224,11 +246,7 @@ public class InventoryUi {
      *
      * @param topY starting Y position of the box
      */
-    private void characterScreen(Graphics2D g2, int topY) {
-        int x = gp.getTileSize();
-        int y = topY;
-        int width = x * 5;
-        int height = gp.getTileSize() * 6;
+    private void drawAttributePanel(Graphics2D g2, int x, int y, int width, int height) {
         drawSubWindow(x, y, width, height, g2);
         g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 12f));
         int textX = x + 10;
@@ -250,7 +268,6 @@ public class InventoryUi {
         g2.drawString("Physique: " + physName, textX, textY); textY += 15;
         g2.drawString("Affinity: " + p.getAffinityNames(), textX, textY); textY += 20;
 
-        // Vẽ nút mở bảng công pháp
         int btnW = gp.getTileSize() * 3;
         int btnH = gp.getTileSize() / 2;
         int btnX = x + (width - btnW) / 2;
@@ -259,6 +276,49 @@ public class InventoryUi {
         g2.setColor(Color.WHITE);
         g2.drawString("Công pháp", btnX + 10, btnY + btnH - 5);
         skillBtn.setBounds(btnX, btnY, btnW, btnH);
+    }
+
+    private void drawEquipmentPanel(Graphics2D g2, int x, int y) {
+        int padding = 8;
+        int charSize = gp.getTileSize() * 3;
+        int slotSize = itemGrid.getSlotSize();
+        int gap = itemGrid.getGap();
+        int width = charSize + padding * 2 + gap + (slotSize + gap) * 5;
+        int height = Math.max(charSize, (slotSize + gap) * 2) + padding * 2;
+        HUDUtils.drawSubWindow(g2, x, y, width, height, new Color(0,80,120,180), Color.CYAN);
+
+        int charX = x + padding;
+        int charY = y + padding;
+        g2.setColor(new Color(128,0,128,200));
+        g2.fillRect(charX, charY, charSize, charSize);
+        g2.drawImage(gp.getPlayer().getDown1(), charX, charY, charSize, charSize, null);
+
+        int startX = charX + charSize + gap;
+        int startY = charY;
+        Point mouse = gp.getMousePosition();
+        equipHover = -1;
+        for (int i = 0; i < SLOT_ORDER.length; i++) {
+            int cx = startX + (i % 5) * (slotSize + gap);
+            int cy = startY + (i / 5) * (slotSize + gap);
+            Rectangle rect = new Rectangle(cx, cy, slotSize, slotSize);
+            equipSlots[i] = rect;
+            g2.setColor(new Color(90,90,90,220));
+            g2.fillRoundRect(cx, cy, slotSize, slotSize, 10, 10);
+            g2.setColor(new Color(0,0,0,160));
+            g2.drawRoundRect(cx, cy, slotSize, slotSize, 10, 10);
+
+            Equipment eq = gp.getPlayer().getEquips().get(SLOT_ORDER[i]);
+            if (eq != null) {
+                g2.drawImage(eq.getIcon(), cx + 4, cy + 4, slotSize - 8, slotSize - 8, null);
+            }
+            if (mouse != null && rect.contains(mouse)) {
+                equipHover = i;
+                g2.setColor(Color.YELLOW);
+                g2.setStroke(new BasicStroke(3f));
+                g2.drawRoundRect(cx, cy, slotSize, slotSize, 10, 10);
+                g2.setStroke(new BasicStroke(1f));
+            }
+        }
     }
 
     private void drawSubWindow(int x, int y, int width, int height, Graphics2D g2) {
@@ -282,6 +342,17 @@ public class InventoryUi {
         if (skillBtn.contains(mx, my)) {
             gp.getUi().getSkillUi().toggle();
             return true;
+        }
+
+        for (int i = 0; i < equipSlots.length; i++) {
+            Rectangle r = equipSlots[i];
+            if (r != null && r.contains(mx, my)) {
+                Equipment eq = gp.getPlayer().getEquips().get(SLOT_ORDER[i]);
+                if (button == MouseEvent.BUTTON3 && eq != null) {
+                    gp.getPlayer().unequip(SLOT_ORDER[i]);
+                }
+                return true;
+            }
         }
 
         int local = computeSlotIndex(baseX, baseY, new Point(mx, my));

--- a/src/game/ui/ItemGridUi.java
+++ b/src/game/ui/ItemGridUi.java
@@ -41,8 +41,8 @@ public class ItemGridUi {
      * @param offset   vị trí bắt đầu hiển thị trong danh sách
      */
     public void draw(Graphics2D g2, int x, int y, List<Item> items,
-                     int selected, int hover, int offset) {
-        int total = (items == null) ? 0 : items.size();
+                     int selected, int hover, int offset, int capacity) {
+        int total = capacity;
         Dimension d = getPreferredSize();
 
         // Khung lớn
@@ -57,15 +57,19 @@ public class ItemGridUi {
             for (int c = 0; c < cols; c++) {
                 int xx = startX + c * (slotSize + gap);
 
+                int idx = offset + r * cols + c;
+                Item it = (idx < items.size()) ? items.get(idx) : null;
+
                 // vẽ nền ô
-                g2.setColor(new Color(90,90,90,220));
+                if (it != null) {
+                    g2.setColor(new Color(90,90,90,220));
+                } else {
+                    g2.setColor(Color.WHITE);
+                }
                 g2.fillRoundRect(xx, yy, slotSize, slotSize, 10, 10);
                 // vẽ khung ô
                 g2.setColor(new Color(0,0,0,160));
                 g2.drawRoundRect(xx, yy, slotSize, slotSize, 10, 10);
-
-                int idx = offset + r * cols + c;
-                Item it = (idx < total) ? items.get(idx) : null;
 
                 if (it != null) {
                     BufferedImage icon = it.getIcon();


### PR DESCRIPTION
## Summary
- add equipment slots with character portrait and attribute panel layout changes
- allow equipment to modify stats and expand bag capacity
- support item drops on ground with pick-up and auto removal

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68ad5767adbc832fb5ba66665aaa8f4d