### PR TITLE
feat: persist equipped items

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -63,3 +63,7 @@ Sửa lỗi và cải tiến:
 - Thêm trang bị vào game
 - test sử dụng trang bị
 - bug lỗi chưa lưu trang bị đang sử dụng
+
+## 1.0.16
+- Lưu và tải lại trang bị đang mặc vào tệp `.txt` với khối `===EQUIPMENT===`.
+- Mỗi trang bị có mã định danh riêng để phân biệt.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 ## Cập nhật
 
+## [1.0.16]
+
+### Thêm
+- Lưu và tải lại trang bị đang mặc vào tệp `.txt` thông qua khối `===EQUIPMENT===`.
+- Mỗi trang bị sở hữu mã định danh duy nhất.
+
 ## [1.0.14]
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -710,6 +710,29 @@ public class Player extends GameActor implements DrawableEntity {
                     .map(it -> it.getName() + " (" + it.getQuantity() + ")")
                     .collect(Collectors.joining(", "));
             lines.add("Itemcủa nhân vật: " + items);
+
+            lines.add("===EQUIPMENT===");
+            EquipSlot[] order = {
+                EquipSlot.ARMOR,
+                EquipSlot.HELMET,
+                EquipSlot.PANTS,
+                EquipSlot.SHOES,
+                EquipSlot.WEAPON1,
+                EquipSlot.WEAPON2,
+                EquipSlot.NECKLACE,
+                EquipSlot.RING1,
+                EquipSlot.RING2,
+                EquipSlot.AMULET
+            };
+            for (EquipSlot slot : order) {
+                EquipmentItem eq = equipment.get(slot);
+                if (eq != null) {
+                    lines.add("- " + slot.name() + ": " + eq.getId() + "|" + eq.getName() + "|" + eq.getDecription());
+                } else {
+                    lines.add("- " + slot.name() + ": none");
+                }
+            }
+
             lines.addAll(realmLog);
             Files.write(file, lines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
         } catch (IOException e) {
@@ -747,11 +770,11 @@ public class Player extends GameActor implements DrawableEntity {
                 if (!items.isEmpty()) {
                     String[] tokens = items.split(",\\s*");
                     for (String token : tokens) {
-                        int idx = token.lastIndexOf(" (");
+                        int idxTok = token.lastIndexOf(" (");
                         int end = token.lastIndexOf(")");
-                        if (idx > 0 && end > idx) {
-                            String name = token.substring(0, idx).trim();
-                            int qty = Integer.parseInt(token.substring(idx + 2, end));
+                        if (idxTok > 0 && end > idxTok) {
+                            String name = token.substring(0, idxTok).trim();
+                            int qty = Integer.parseInt(token.substring(idxTok + 2, end));
                             Item it = createItemByName(name, qty);
                             if (it != null) bag.add(it);
                         }
@@ -759,15 +782,48 @@ public class Player extends GameActor implements DrawableEntity {
                 }
             }
 
+            int idxLine = 2;
+            if (idxLine < lines.size() && lines.get(idxLine).trim().equals("===EQUIPMENT===")) {
+                idxLine++;
+                equipment.clear();
+                while (idxLine < lines.size()) {
+                    String line = lines.get(idxLine).trim();
+                    if (!line.startsWith("-")) break;
+                    line = line.substring(1).trim();
+                    int colon = line.indexOf(":");
+                    if (colon < 0) { idxLine++; continue; }
+                    String slotName = line.substring(0, colon).trim();
+                    String data = line.substring(colon + 1).trim();
+                    EquipSlot slot;
+                    try {
+                        slot = EquipSlot.valueOf(slotName);
+                    } catch (IllegalArgumentException e) {
+                        idxLine++; continue;
+                    }
+                    if (!data.equalsIgnoreCase("none")) {
+                        String[] partsEq = data.split("\\|");
+                        String id = partsEq.length > 0 ? partsEq[0].trim() : "";
+                        String nameEq = partsEq.length > 1 ? partsEq[1].trim() : "";
+                        String descEq = partsEq.length > 2 ? partsEq[2].trim() : "";
+                        EquipmentItem eq = createEquipmentFromSlot(id, nameEq, descEq, slot);
+                        if (eq != null) {
+                            equipment.put(slot, eq);
+                            applyBonuses(eq);
+                        }
+                    }
+                    idxLine++;
+                }
+            }
+
             // Realm log
             realmLog.clear();
-            if (lines.size() > 2) {
-                realmLog.addAll(lines.subList(2, lines.size()));
+            if (lines.size() > idxLine) {
+                realmLog.addAll(lines.subList(idxLine, lines.size()));
             }
 
             // Parse last block for stats
             int last = -1;
-            for (int i = 2; i < lines.size(); i++) {
+            for (int i = idxLine; i < lines.size(); i++) {
                 if (lines.get(i).startsWith("=============================")) {
                     last = i;
                 }
@@ -974,6 +1030,39 @@ public class Player extends GameActor implements DrawableEntity {
             
             default -> null;
         };
+    }
+
+    private EquipmentItem createEquipmentFromSlot(String id, String name, String desc, EquipSlot slot) {
+        EquipType type = switch (slot) {
+            case ARMOR -> EquipType.ARMOR;
+            case HELMET -> EquipType.HELMET;
+            case PANTS -> EquipType.PANTS;
+            case SHOES -> EquipType.SHOES;
+            case NECKLACE -> EquipType.NECKLACE;
+            case AMULET -> EquipType.AMULET;
+            case RING1, RING2 -> EquipType.RING;
+            case WEAPON1, WEAPON2 -> EquipType.WEAPON;
+        };
+        String icon = switch (slot) {
+            case ARMOR -> "/data/item/equipment/armor.png";
+            case HELMET -> "/data/item/equipment/helmet.png";
+            case PANTS -> "/data/item/equipment/pants.png";
+            case SHOES -> "/data/item/equipment/shoes.png";
+            case NECKLACE -> "/data/item/equipment/ring.png";
+            case AMULET -> "/data/item/equipment/d_1.png";
+            case RING1, RING2 -> "/data/item/equipment/ring.png";
+            case WEAPON1, WEAPON2 -> "/data/item/equipment/sword.png";
+        };
+        if (desc == null || desc.isEmpty()) {
+            desc = switch (type) {
+                case ARMOR, HELMET, PANTS, SHOES -> "+3 DEF";
+                case WEAPON -> "+10 ATTACK";
+                case NECKLACE -> "+10 SOULD";
+                case RING -> "+10 ô kho";
+                case AMULET -> "Chưa có tác dụng";
+            };
+        }
+        return new EquipmentItem(id, name, desc, icon, type);
     }
 
     // -------- Random Physique/Affinity ---------

--- a/src/game/entity/item/EquipmentItem.java
+++ b/src/game/entity/item/EquipmentItem.java
@@ -2,6 +2,7 @@ package game.entity.item;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.UUID;
 import javax.imageio.ImageIO;
 
 import game.entity.Player;
@@ -12,11 +13,24 @@ public class EquipmentItem extends Item {
     private final EquipType type;
     private final String iconPath;
     private final BufferedImage icon;
+    /** Unique identifier for this equipment. */
+    private final String id;
 
+    /**
+     * Create equipment with an auto-generated unique id.
+     */
     public EquipmentItem(String name, String desc, String iconPath, EquipType type) {
+        this(type.name() + "#" + UUID.randomUUID().toString(), name, desc, iconPath, type);
+    }
+
+    /**
+     * Create equipment with a specified id.
+     */
+    public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type) {
         super(name, desc, 1, 1);
         this.type = type;
         this.iconPath = iconPath;
+        this.id = id;
         BufferedImage img = null;
         if (iconPath != null) {
             try {
@@ -30,6 +44,14 @@ public class EquipmentItem extends Item {
 
     public EquipType getType() {
         return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIconPath() {
+        return iconPath;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- save currently equipped gear with unique IDs
- load equipment on start from new `===EQUIPMENT===` block
- document equipment persistence in README and Change log

## Testing
- `javac -d bin $(find src -name '*.java') && echo compiled`


------
https://chatgpt.com/codex/tasks/task_e_68ad6e4a3008832fb81eadcef24db224