### PR TITLE
Persist equipped gear with unique identifiers

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -63,3 +63,8 @@ Sửa lỗi và cải tiến:
 - Thêm trang bị vào game
 - test sử dụng trang bị
 - bug lỗi chưa lưu trang bị đang sử dụng
+
+## 1.0.16
+- Lưu các trang bị đang mặc vào tệp `.txt` và đọc lại khi khởi động game.
+- Mỗi trang bị có mã định danh riêng để phân biệt thuộc tính.
+- Cập nhật README mô tả tính năng mới.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 ## Cập nhật
 
+## [1.0.15]
+
+### Thêm
+- Lưu và tải trang bị đang mặc vào tệp `.txt` khi thoát và khởi động game.
+- Mỗi trang bị có mã định danh riêng (ví dụ `ARMOR#0000001`) để phân biệt thuộc tính.
+
+### Sửa lỗi
+- Khắc phục lỗi không lưu lại trang bị đang sử dụng.
+
 ## [1.0.14]
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -710,6 +710,14 @@ public class Player extends GameActor implements DrawableEntity {
                     .map(it -> it.getName() + " (" + it.getQuantity() + ")")
                     .collect(Collectors.joining(", "));
             lines.add("Itemcủa nhân vật: " + items);
+
+            lines.add("===EQUIPMENT===");
+            String[] order = {"ARMOR","HELMET","PANTS","SHOES","WEAPON1","WEAPON2","NECKLACE","RING1","RING2","AMULET"};
+            EquipSlot[] slots = {EquipSlot.ARMOR,EquipSlot.HELMET,EquipSlot.PANTS,EquipSlot.SHOES,EquipSlot.WEAPON1,EquipSlot.WEAPON2,EquipSlot.NECKLACE,EquipSlot.RING1,EquipSlot.RING2,EquipSlot.AMULET};
+            for (int i = 0; i < order.length; i++) {
+                lines.add("- " + order[i] + ": " + formatEquipment(equipment.get(slots[i])));
+            }
+
             lines.addAll(realmLog);
             Files.write(file, lines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
         } catch (IOException e) {
@@ -759,10 +767,41 @@ public class Player extends GameActor implements DrawableEntity {
                 }
             }
 
+            // Equipment section
+            int equipHeader = lines.indexOf("===EQUIPMENT===");
+            int logStart = 2;
+            equipment.clear();
+            if (equipHeader != -1) {
+                int i = equipHeader + 1;
+                for (; i < lines.size(); i++) {
+                    String l = lines.get(i);
+                    if (!l.startsWith("- ")) break;
+                    int colon = l.indexOf(':');
+                    if (colon < 0) continue;
+                    String slotName = l.substring(2, colon).trim();
+                    String data = l.substring(colon + 1).trim();
+                    EquipSlot slot = null;
+                    try { slot = EquipSlot.valueOf(slotName); } catch (IllegalArgumentException e) { /* ignore */ }
+                    if (slot == null) continue;
+                    if (!data.equalsIgnoreCase("none")) {
+                        String[] arr = data.split("\\|");
+                        String id = arr[0].trim();
+                        String name = arr.length > 1 ? arr[1].trim() : "";
+                        String desc = arr.length > 2 ? arr[2].trim() : "";
+                        EquipmentItem eq = createEquipmentFromData(id, name, desc, slot);
+                        if (eq != null) {
+                            equipment.put(slot, eq);
+                            applyBonuses(eq);
+                        }
+                    }
+                }
+                logStart = i;
+            }
+
             // Realm log
             realmLog.clear();
-            if (lines.size() > 2) {
-                realmLog.addAll(lines.subList(2, lines.size()));
+            if (lines.size() > logStart) {
+                realmLog.addAll(lines.subList(logStart, lines.size()));
             }
 
             // Parse last block for stats
@@ -974,6 +1013,29 @@ public class Player extends GameActor implements DrawableEntity {
             
             default -> null;
         };
+    }
+
+    private String formatEquipment(EquipmentItem eq) {
+        if (eq == null) return "none";
+        return eq.getId() + " | " + eq.getName() + " | " + eq.getDecription();
+    }
+
+    private EquipmentItem createEquipmentFromData(String id, String name, String desc, EquipSlot slot) {
+        Item base = createItemByName(name, 1);
+        if (base instanceof EquipmentItem ei) {
+            return new EquipmentItem(id, name, desc, ei.getIconPath(), ei.getType());
+        }
+        EquipType type = switch (slot) {
+            case HELMET -> EquipType.HELMET;
+            case ARMOR -> EquipType.ARMOR;
+            case SHOES -> EquipType.SHOES;
+            case PANTS -> EquipType.PANTS;
+            case NECKLACE -> EquipType.NECKLACE;
+            case AMULET -> EquipType.AMULET;
+            case RING1, RING2 -> EquipType.RING;
+            case WEAPON1, WEAPON2 -> EquipType.WEAPON;
+        };
+        return new EquipmentItem(id, name, desc, null, type);
     }
 
     // -------- Random Physique/Affinity ---------

--- a/src/game/entity/item/EquipmentItem.java
+++ b/src/game/entity/item/EquipmentItem.java
@@ -2,6 +2,8 @@ package game.entity.item;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.imageio.ImageIO;
 
 import game.entity.Player;
@@ -9,14 +11,22 @@ import game.enums.EquipType;
 
 /** Basic equipment item that can be equipped in a slot. */
 public class EquipmentItem extends Item {
+    private static final AtomicInteger ID_GEN = new AtomicInteger();
+
     private final EquipType type;
     private final String iconPath;
     private final BufferedImage icon;
+    private final String id;
 
     public EquipmentItem(String name, String desc, String iconPath, EquipType type) {
+        this(null, name, desc, iconPath, type);
+    }
+
+    public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type) {
         super(name, desc, 1, 1);
         this.type = type;
         this.iconPath = iconPath;
+        this.id = (id != null) ? id : generateId(type);
         BufferedImage img = null;
         if (iconPath != null) {
             try {
@@ -28,8 +38,20 @@ public class EquipmentItem extends Item {
         this.icon = img;
     }
 
+    private static String generateId(EquipType type) {
+        return type.name() + String.format("#%07d", ID_GEN.incrementAndGet());
+    }
+
     public EquipType getType() {
         return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIconPath() {
+        return iconPath;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- store currently equipped items (armor, weapons, accessories, etc.) into the save file with unique IDs
- load equipment back on game start and generate IDs for gear
- document equipment saving and unique IDs in README and Change log

## Testing
- `javac @sources.txt -d bin`

------
https://chatgpt.com/codex/tasks/task_e_68ad6e4cd0f4832fa659c061ff777716