### PR TITLE
feat: add ground loot drops

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -73,3 +73,8 @@ Sửa lỗi và cải tiến:
 - Lên cấp chỉ tăng thuộc tính gốc, trang bị cộng thêm vào bảng thuộc tính mà không làm thay đổi giá trị gốc.
 - Cập nhật ghi log thuộc tính trong tệp lưu theo hai phần "Thuộc tính gốc" và "Thuộc tính sau khi mặc đồ".
 - Chỉnh sửa README mô tả thay đổi.
+
+## 1.0.18
+- Quái vật rơi vật phẩm 100% và xuất hiện trên mặt đất trong bán kính 20px quanh vị trí chết.
+- Người chơi phải nhấp vào vật phẩm để nhặt; nếu túi đầy hiển thị thông báo bên phải màn hình trong 3 giây.
+- Vật phẩm nằm trên đất sẽ tự biến mất sau 2 phút nếu không được nhặt.

--- a/Change.txt
+++ b/Change.txt
@@ -78,3 +78,6 @@ Sửa lỗi và cải tiến:
 - Quái vật rơi vật phẩm 100% và xuất hiện trên mặt đất trong bán kính 20px quanh vị trí chết.
 - Người chơi phải nhấp vào vật phẩm để nhặt; nếu túi đầy hiển thị thông báo bên phải màn hình trong 3 giây.
 - Vật phẩm nằm trên đất sẽ tự biến mất sau 2 phút nếu không được nhặt.
+
+## 1.0.19
+- Sửa lỗi tải thuộc tính khiến ATTACK/DEF bằng 0 và không gây sát thương lên quái vật.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 ## Cập nhật
 
+## [1.0.18]
+
+### Thêm
+- Quái vật rơi vật phẩm 100%, vật phẩm xuất hiện trên đất tại vị trí ngẫu nhiên quanh nơi chết.
+- Người chơi phải nhấp vào vật phẩm trên đất để nhặt, item biến mất sau 2 phút nếu không nhặt.
+- Hiện thông báo "Khung vật phẩm đầy" bên phải màn hình trong 3 giây khi túi đồ đầy.
+
 ## [1.0.17]
 
 ### Sửa lỗi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 ## Cập nhật
 
+## [1.0.19]
+
+### Sửa lỗi
+- Khắc phục lỗi đọc thuộc tính khiến ATTACK và DEF hiển thị 0 và quái không nhận sát thương.
+
 ## [1.0.18]
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -440,10 +440,11 @@ public class Player extends GameActor implements DrawableEntity {
         return UtilityTool.scaleImage(image, gp.getTileSize(), gp.getTileSize());
     }
     
-    // Thêm item vào túi và lưu
-    public void addItem(Item item) {
-        bag.add(item);
+    // Thêm item vào túi và lưu, trả về true nếu thành công
+    public boolean addItem(Item item) {
+        boolean added = bag.add(item);
         saveProfile();
+        return added;
     }
 
     // Sử dụng item

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -851,10 +851,16 @@ public class Player extends GameActor implements DrawableEntity {
                     last = i;
                 }
             }
-            if (last == -1 || last + 1 >= lines.size()) return true;
+            if (last == -1 || last + 1 >= lines.size()) {
+                refreshStats();
+                return true;
+            }
 
             List<String> block = lines.subList(last, lines.size());
-            if (block.size() < 2) return true;
+            if (block.size() < 2) {
+                refreshStats();
+                return true;
+            }
 
             String realmLine = block.get(1);
             String realmPart = realmLine.substring("cảnh giới ".length(), realmLine.indexOf(" - ")).trim();
@@ -1155,7 +1161,12 @@ public class Player extends GameActor implements DrawableEntity {
     private void refreshStats() {
         atts().setStarts(new EnumMap<>(baseAtts.getStarts()));
         for (Attr a : Attr.values()) {
-            atts().setMax(a, baseAtts.getMax(a));
+            int max = baseAtts.getMax(a);
+            if (max > 0) {
+                atts().setMax(a, max);
+            } else {
+                atts().setMax(a, Integer.MAX_VALUE);
+            }
         }
         for (EquipmentItem eq : equipment.values()) {
             switch (eq.getType()) {

--- a/src/game/entity/inventory/Inventory.java
+++ b/src/game/entity/inventory/Inventory.java
@@ -11,9 +11,11 @@ public class Inventory {
 
     /**
      * Thêm item có cộng dồn + kiểm tra giới hạn ô.
+     *
+     * @return true nếu thêm được toàn bộ số lượng, false nếu kho đầy.
      */
-    public void add(Item incoming) {
-        if (incoming == null || incoming.getQuantity() <= 0) return;
+    public boolean add(Item incoming) {
+        if (incoming == null || incoming.getQuantity() <= 0) return false;
 
         int remain = incoming.getQuantity();
 
@@ -25,7 +27,7 @@ public class Inventory {
             int moved = Math.min(space, remain);
             it.increaseQuantity(moved);
             remain -= moved;
-            if (remain == 0) return;
+            if (remain == 0) return true;
         }
 
         // 2) Tạo thêm các stack mới cho phần còn lại (chia theo maxStack)
@@ -37,6 +39,7 @@ public class Inventory {
         }
 
         // Nếu vẫn còn dư thì kho đã đầy -> bỏ phần dư
+        return remain == 0;
     }
     
         public boolean remove(Item i) {

--- a/src/game/entity/item/MaterialItem.java
+++ b/src/game/entity/item/MaterialItem.java
@@ -1,0 +1,45 @@
+package game.entity.item;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import game.entity.Player;
+
+/** Simple material item dropped by monsters. */
+public class MaterialItem extends Item {
+    private final String iconPath;
+    private final BufferedImage icon;
+
+    public MaterialItem(String name, String desc, String iconPath, int quantity, int maxStack) {
+        super(name, desc, quantity, maxStack);
+        this.iconPath = iconPath;
+        BufferedImage img;
+        try {
+            img = ImageIO.read(getClass().getResourceAsStream(iconPath));
+        } catch (IOException | IllegalArgumentException e) {
+            img = null;
+        }
+        this.icon = img;
+    }
+
+    private MaterialItem(MaterialItem other, int qty) {
+        this(other.getName(), other.getDecription(), other.iconPath, qty, other.getMaxStack());
+    }
+
+    @Override
+    public Item copyWithQuantity(int qty) {
+        return new MaterialItem(this, qty);
+    }
+
+    @Override
+    public void use(Player p) {
+        // Materials have no use yet
+    }
+
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
+}

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -312,18 +312,24 @@ public abstract class Monster extends GameActor {
     }
 
     /**
-     * Rơi vật phẩm khi chết.
+     * Rơi vật phẩm khi chết (100%).
      */
     public void dropItem() {
-        if (random.nextInt(100) < getDropChance()) {
-        	 gp.getPlayer().addItem(new game.entity.item.elixir.HealthPotion(30, 1));
+        for (var item : createDropItems()) {
+            int dx = getWorldX() + random.nextInt(41) - 20;
+            int dy = getWorldY() + random.nextInt(41) - 20;
+            gp.getDroppedItems().add(new game.object.DroppedItem(item, dx, dy, gp));
         }
     }
 
     /**
-     * @return tỉ lệ rơi vật phẩm
+     * Tạo danh sách vật phẩm rơi ra.
      */
-    protected int getDropChance() { return 30; }
+    protected java.util.List<game.entity.item.Item> createDropItems() {
+        java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
+        list.add(new game.entity.item.elixir.HealthPotion(30, 1));
+        return list;
+    }
 
     /**
      * @return thời gian hồi chiêu tấn công

--- a/src/game/entity/monster/Orc.java
+++ b/src/game/entity/monster/Orc.java
@@ -70,6 +70,14 @@ public class Orc extends Monster {
         attackRight2 = setup("/data/monster/orc/orc_attack_right_2", gp.getTileSize() * 2, gp.getTileSize());
     }
 
+    @Override
+    protected java.util.List<game.entity.item.Item> createDropItems() {
+        java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
+        list.add(new game.entity.item.MaterialItem("Xương Orc", "Bone", "/data/item/orc/ORC_Bone.png", 1, 20));
+        list.add(new game.entity.item.MaterialItem("Thịt Orc", "Flesh", "/data/item/orc/ORC_Flesh.png", 1, 20));
+        return list;
+    }
+
     /**
      * Vẽ Orc và thanh máu.
      */

--- a/src/game/entity/monster/SkeletonLord.java
+++ b/src/game/entity/monster/SkeletonLord.java
@@ -70,6 +70,13 @@ public class SkeletonLord extends Monster {
         attackRight2 = setup("/data/monster/skeleton/skeletonlord_attack_right_2", gp.getTileSize() * 2, gp.getTileSize());
     }
 
+    @Override
+    protected java.util.List<game.entity.item.Item> createDropItems() {
+        java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
+        list.add(new game.entity.item.MaterialItem("Xương Skeleton", "Bone", "/data/item/skeleton/SKELETON_Bone.png", 1, 20));
+        return list;
+    }
+
     /**
      * Vẽ Skeleton Lord cùng thanh máu.
      */

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -20,6 +20,7 @@ import game.keyhandler.KeyHandler;
 import game.mouseclick.MouseHandler;
 import game.object.ObjectManager;
 import game.object.SuperObject;
+import game.object.DroppedItem;
 import game.tile.TileManager;
 import game.ui.Ui;
 import game.entity.monster.MonsterZone;
@@ -49,8 +50,9 @@ public class GamePanel extends JPanel implements Runnable {
 	private final Player player = new Player(this);
 	private final TileManager tileManager = new TileManager(this);
 	private final CollisionChecker checkCollision = new CollisionChecker(this);
-        private final List<SuperObject> objects = new ArrayList<>();
-        private final List<Entity> npcs = new ArrayList<>();
+    private final List<SuperObject> objects = new ArrayList<>();
+    private final List<DroppedItem> droppedItems = new ArrayList<>();
+    private final List<Entity> npcs = new ArrayList<>();
     private final List<Entity> monsters = new ArrayList<>();
     private final ObjectManager objectManager = new ObjectManager(this);
     private final Ui ui = new Ui(this);
@@ -131,6 +133,7 @@ public class GamePanel extends JPanel implements Runnable {
                             m.update();
                         }
                     }
+                    droppedItems.removeIf(DroppedItem::isExpired);
                 }
                 if(gameState == pauseState) {}
         }
@@ -146,7 +149,8 @@ public class GamePanel extends JPanel implements Runnable {
 		//Check object
 		List<DrawableEntity> drawList = new ArrayList<>();
 
-		drawList.addAll(objects);
+                drawList.addAll(objects);
+                drawList.addAll(droppedItems);
                 drawList.addAll(npcs);
                 drawList.addAll(monsters);
                 drawList.add(player);
@@ -180,7 +184,8 @@ public class GamePanel extends JPanel implements Runnable {
 	public TileManager getTileManager() { return tileManager; }
 	public CollisionChecker getCheckCollision() { return checkCollision; }
 	public ObjectManager getObjectManager() { return objectManager; } 
-	public List<SuperObject> getObjects() { return objects; }
+    public List<SuperObject> getObjects() { return objects; }
+    public List<DroppedItem> getDroppedItems() { return droppedItems; }
     public List<Entity> getNpcs() { return npcs; }
     public List<Entity> getMonsters() { return monsters; }
     public List<MonsterZone> getMonsterZones() { return monsterZones; }

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -26,7 +26,24 @@ public class MouseHandler implements MouseListener, MouseWheelListener {
         if (gp.keyH.isiPressed()) {
             return;
         }
-            // Right mouse pressed
+        if (e.getButton() == MouseEvent.BUTTON1) {
+            int mouseX = e.getX();
+            int mouseY = e.getY();
+            int worldX = gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() + mouseX;
+            int worldY = gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() + mouseY;
+            for (int i = 0; i < gp.getDroppedItems().size(); i++) {
+                var di = gp.getDroppedItems().get(i);
+                if (di.contains(worldX, worldY)) {
+                    if (gp.getPlayer().addItem(di.getItem())) {
+                        gp.getDroppedItems().remove(i);
+                    } else {
+                        gp.getUi().showMessage("Khung vật phẩm đầy", 180);
+                    }
+                    return;
+                }
+            }
+        }
+        // Right mouse pressed
         if (e.getButton() == MouseEvent.BUTTON3) {
             //Tọa độ x,y trên màn hình
             int mouseX = e.getX();

--- a/src/game/object/DroppedItem.java
+++ b/src/game/object/DroppedItem.java
@@ -1,0 +1,39 @@
+package game.object;
+
+import java.awt.Rectangle;
+
+import game.entity.item.Item;
+import game.main.GamePanel;
+import game.util.UtilityTool;
+
+/** Object representing an item dropped on the ground. */
+public class DroppedItem extends SuperObject {
+    private final Item item;
+    private final long dropTime;
+    private static final long LIFETIME_MS = 120000; // 2 minutes
+
+    public DroppedItem(Item item, int worldX, int worldY, GamePanel gp) {
+        this.item = item;
+        setWorldX(worldX);
+        setWorldY(worldY);
+        setImage(UtilityTool.scaleImage(item.getIcon(), gp.getTileSize(), gp.getTileSize()));
+        setCollisionArea(new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize()));
+        setCollisionDefaultX(0);
+        setCollisionDefaultY(0);
+        dropTime = System.currentTimeMillis();
+    }
+
+    public Item getItem() { return item; }
+
+    /** Check if the item has existed longer than its lifetime. */
+    public boolean isExpired() {
+        return System.currentTimeMillis() - dropTime > LIFETIME_MS;
+    }
+
+    /** Checks if a world coordinate lies within this item. */
+    public boolean contains(int worldX, int worldY) {
+        Rectangle r = new Rectangle(getWorldX(), getWorldY(),
+                getCollisionArea().width, getCollisionArea().height);
+        return r.contains(worldX, worldY);
+    }
+}

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -39,9 +39,10 @@ public class Ui {
         this.skillUi = new SkillUi(gp);
     }
 
-    public void showMessage(String text) {
+    public void showMessage(String text, int duration) {
         message = text;
         messageOn = true;
+        messageCouter = duration;
     }
 
     public void draw(Graphics2D g2) {
@@ -63,6 +64,9 @@ public class Ui {
             }
         }
         hud.draw(g2);
+        if (messageOn) {
+            drawMessage(g2);
+        }
         if (damageCounter > 0) {
             g2.setColor(new Color(255, 0, 0, 100));
             g2.fillRect(0, 0, gp.getScreenWidth(), gp.getScreenHeight());
@@ -120,6 +124,20 @@ public class Ui {
             g2.setFont(oldFont);
             g2.setStroke(oldStroke);
         }
+    }
+
+    private void drawMessage(Graphics2D g2) {
+        int padding = 10;
+        int width = g2.getFontMetrics().stringWidth(message) + padding * 2;
+        int height = 40;
+        int x = gp.getScreenWidth() - width - 20;
+        int y = gp.getScreenHeight() / 4;
+        g2.setColor(new Color(0, 0, 0, 150));
+        g2.fillRoundRect(x, y, width, height, 15, 15);
+        g2.setColor(Color.WHITE);
+        g2.drawString(message, x + padding, y + height - 15);
+        messageCouter--;
+        if (messageCouter <= 0) messageOn = false;
     }
 
     private void drawPauseScreen() {


### PR DESCRIPTION
## Summary
- spawn monster drops on the ground with 2-minute lifetime
- allow clicking ground loot to collect or show a 3s 'inventory full' notice
- add simple material items and update inventory logic

## Testing
- `javac $(find src -name "*.java") -d bin`

------
https://chatgpt.com/codex/tasks/task_e_68ad7eaa4298832fba09f75dd31ff6f2