### PR TITLE
feat: add ground item drops

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -79,3 +79,7 @@ Sửa lỗi và cải tiến:
 - Vật phẩm rơi xuất hiện ngẫu nhiên quanh vị trí quái và người chơi phải click để nhặt.
 - Khi kho đồ đầy, hiển thị thông báo "Khung vật phẩm đầy" ở góc phải trong 3 giây.
 - Vật phẩm rơi sẽ biến mất sau 2 phút nếu không được nhặt.
+
+## 1.0.19
+- Sửa lỗi thuộc tính ATTACK/DEF bị đặt về 0 khiến đòn tấn công không gây sát thương.
+- Các thuộc tính không có giới hạn nay mặc định dùng giá trị tối đa vô hạn.

--- a/Change.txt
+++ b/Change.txt
@@ -73,3 +73,9 @@ Sửa lỗi và cải tiến:
 - Lên cấp chỉ tăng thuộc tính gốc, trang bị cộng thêm vào bảng thuộc tính mà không làm thay đổi giá trị gốc.
 - Cập nhật ghi log thuộc tính trong tệp lưu theo hai phần "Thuộc tính gốc" và "Thuộc tính sau khi mặc đồ".
 - Chỉnh sửa README mô tả thay đổi.
+
+## 1.0.18
+- Quái vật rơi vật phẩm dựa trên danh sách định nghĩa với tỷ lệ 100%.
+- Vật phẩm rơi xuất hiện ngẫu nhiên quanh vị trí quái và người chơi phải click để nhặt.
+- Khi kho đồ đầy, hiển thị thông báo "Khung vật phẩm đầy" ở góc phải trong 3 giây.
+- Vật phẩm rơi sẽ biến mất sau 2 phút nếu không được nhặt.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@
 ### Sửa lỗi
 - Khi kho đồ đầy và cố nhặt vật phẩm, trò chơi hiển thị thông báo "Khung vật phẩm đầy".
 
+## [1.0.19]
+
+### Sửa lỗi
+- Thuộc tính ATTACK và DEF hiển thị 0 khiến nhân vật không gây sát thương khi tấn công.
+
 ## [1.0.17]
 
 ### Sửa lỗi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 ## Cập nhật
 
+## [1.0.18]
+
+### Thêm
+- Quái vật rơi vật phẩm 100% theo danh sách định nghĩa và xuất hiện ngẫu nhiên quanh vị trí chết.
+- Vật phẩm rơi tồn tại trên đất, người chơi phải click chuột để nhặt.
+- Item tự động biến mất sau 2 phút nếu không được nhặt.
+
+### Sửa lỗi
+- Khi kho đồ đầy và cố nhặt vật phẩm, trò chơi hiển thị thông báo "Khung vật phẩm đầy".
+
 ## [1.0.17]
 
 ### Sửa lỗi

--- a/src/game/entity/attributes/Attributes.java
+++ b/src/game/entity/attributes/Attributes.java
@@ -39,8 +39,11 @@ public class Attributes {
 
     /**
      * Lấy giá trị tối đa của thuộc tính.
+     * <p>
+     * Mặc định các thuộc tính như ATTACK, DEF không có giới hạn nên giá trị
+     * tối đa sẽ là {@link Integer#MAX_VALUE} nếu chưa được thiết lập.
      */
-    public int getMax(Attr k) { return maxStats.getOrDefault(k, 0); }
+    public int getMax(Attr k) { return maxStats.getOrDefault(k, Integer.MAX_VALUE); }
 
     /**
      * Gán giá trị tối đa của thuộc tính.

--- a/src/game/entity/inventory/Inventory.java
+++ b/src/game/entity/inventory/Inventory.java
@@ -38,6 +38,32 @@ public class Inventory {
 
         // Nếu vẫn còn dư thì kho đã đầy -> bỏ phần dư
     }
+
+    /**
+     * Kiểm tra xem item có thể thêm hoàn toàn vào kho hay không.
+     *
+     * @param incoming item cần kiểm tra
+     * @return true nếu toàn bộ item có thể thêm, ngược lại false
+     */
+    public boolean canAdd(Item incoming) {
+        if (incoming == null || incoming.getQuantity() <= 0) return true;
+
+        int remain = incoming.getQuantity();
+
+        // 1) Tính phần có thể gộp vào các stack hiện có
+        for (Item it : items) {
+            if (!it.isSameStack(incoming)) continue;
+            int space = it.getMaxStack() - it.getQuantity();
+            if (space <= 0) continue;
+            remain -= Math.min(space, remain);
+            if (remain == 0) return true;
+        }
+
+        // 2) Kiểm tra số ô trống còn lại đủ chứa phần dư hay không
+        int freeSlots = capacity - items.size();
+        int neededSlots = (int) Math.ceil(remain / (double) incoming.getMaxStack());
+        return freeSlots >= neededSlots;
+    }
     
         public boolean remove(Item i) {
                 return items.remove(i);

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -312,18 +312,26 @@ public abstract class Monster extends GameActor {
     }
 
     /**
-     * Rơi vật phẩm khi chết.
+     * Rơi vật phẩm khi chết (100% cho danh sách trả về từ {@link #getDropItems()}).
+     * Vật phẩm xuất hiện ngẫu nhiên quanh vị trí quái vật trong bán kính 20 pixel.
      */
     public void dropItem() {
-        if (random.nextInt(100) < getDropChance()) {
-        	 gp.getPlayer().addItem(new game.entity.item.elixir.HealthPotion(30, 1));
+        java.util.List<game.entity.item.Item> drops = getDropItems();
+        for (game.entity.item.Item item : drops) {
+            int dx = random.nextInt(41) - 20; // [-20,20]
+            int dy = random.nextInt(41) - 20;
+            int x = getWorldX() + dx;
+            int y = getWorldY() + dy;
+            gp.addDroppedItem(new game.object.OBJ_DroppedItem(item, x, y, gp));
         }
     }
 
     /**
-     * @return tỉ lệ rơi vật phẩm
+     * Danh sách vật phẩm sẽ rơi khi quái chết.
      */
-    protected int getDropChance() { return 30; }
+    protected java.util.List<game.entity.item.Item> getDropItems() {
+        return java.util.Collections.emptyList();
+    }
 
     /**
      * @return thời gian hồi chiêu tấn công

--- a/src/game/entity/monster/Orc.java
+++ b/src/game/entity/monster/Orc.java
@@ -8,6 +8,7 @@ import java.awt.image.BufferedImage;
 import game.enums.Attr;
 import game.main.GamePanel;
 import game.util.CameraHelper;
+import game.entity.item.Item;
 
 /**
  * Quái vật Orc, đuổi theo và tấn công cận chiến người chơi.
@@ -48,6 +49,13 @@ public class Orc extends Monster {
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
         detectionRange = 8 * gp.getTileSize();
         loadImages();
+    }
+
+    @Override
+    protected java.util.List<Item> getDropItems() {
+        java.util.List<Item> drops = new java.util.ArrayList<>();
+        drops.add(new game.entity.item.elixir.HealthPotion(50, 1));
+        return drops;
     }
 
     /** Tải hình ảnh di chuyển và tấn công */

--- a/src/game/entity/monster/SkeletonLord.java
+++ b/src/game/entity/monster/SkeletonLord.java
@@ -8,6 +8,7 @@ import java.awt.image.BufferedImage;
 import game.enums.Attr;
 import game.main.GamePanel;
 import game.util.CameraHelper;
+import game.entity.item.Item;
 
 /**
  * Quái vật Skeleton Lord.
@@ -48,6 +49,14 @@ public class SkeletonLord extends Monster {
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
         detectionRange = 10 * gp.getTileSize();
         loadImages();
+    }
+
+    @Override
+    protected java.util.List<Item> getDropItems() {
+        java.util.List<Item> drops = new java.util.ArrayList<>();
+        drops.add(new game.entity.item.elixir.SpiritPotion(200, 1));
+        drops.add(new game.entity.item.elixir.HealthPotion(50, 2));
+        return drops;
     }
 
     /** Tải ảnh di chuyển và tấn công */

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -20,6 +21,7 @@ import game.keyhandler.KeyHandler;
 import game.mouseclick.MouseHandler;
 import game.object.ObjectManager;
 import game.object.SuperObject;
+import game.object.OBJ_DroppedItem;
 import game.tile.TileManager;
 import game.ui.Ui;
 import game.entity.monster.MonsterZone;
@@ -52,6 +54,7 @@ public class GamePanel extends JPanel implements Runnable {
         private final List<SuperObject> objects = new ArrayList<>();
         private final List<Entity> npcs = new ArrayList<>();
     private final List<Entity> monsters = new ArrayList<>();
+    private final List<OBJ_DroppedItem> droppedItems = new ArrayList<>();
     private final ObjectManager objectManager = new ObjectManager(this);
     private final Ui ui = new Ui(this);
     private final List<MonsterZone> monsterZones = new ArrayList<>();
@@ -131,6 +134,7 @@ public class GamePanel extends JPanel implements Runnable {
                             m.update();
                         }
                     }
+                    droppedItems.removeIf(OBJ_DroppedItem::isExpired);
                 }
                 if(gameState == pauseState) {}
         }
@@ -144,9 +148,10 @@ public class GamePanel extends JPanel implements Runnable {
 		Graphics2D g2 = (Graphics2D)g;
 		tileManager.draw(g2);
 		//Check object
-		List<DrawableEntity> drawList = new ArrayList<>();
+                List<DrawableEntity> drawList = new ArrayList<>();
 
-		drawList.addAll(objects);
+                drawList.addAll(objects);
+                drawList.addAll(droppedItems);
                 drawList.addAll(npcs);
                 drawList.addAll(monsters);
                 drawList.add(player);
@@ -184,6 +189,24 @@ public class GamePanel extends JPanel implements Runnable {
     public List<Entity> getNpcs() { return npcs; }
     public List<Entity> getMonsters() { return monsters; }
     public List<MonsterZone> getMonsterZones() { return monsterZones; }
+
+    public List<OBJ_DroppedItem> getDroppedItems() { return droppedItems; }
+    public void addDroppedItem(OBJ_DroppedItem item) { droppedItems.add(item); }
+
+    /** Tìm item rơi tại vị trí thế giới đã cho. */
+    public OBJ_DroppedItem getDroppedItemAt(int worldX, int worldY) {
+        for (OBJ_DroppedItem di : droppedItems) {
+            Rectangle r = new Rectangle(
+                    di.getWorldX() + di.getCollisionArea().x,
+                    di.getWorldY() + di.getCollisionArea().y,
+                    di.getCollisionArea().width,
+                    di.getCollisionArea().height);
+            if (r.contains(worldX, worldY)) {
+                return di;
+            }
+        }
+        return null;
+    }
 
 	public int getGameState() { return gameState; }
 	public GamePanel setGameState(int gameState) { this.gameState = gameState; return this; }

--- a/src/game/mouseclick/MouseHandler.java
+++ b/src/game/mouseclick/MouseHandler.java
@@ -6,6 +6,7 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 
 import game.main.GamePanel;
+import game.object.OBJ_DroppedItem;
 
 /**
  * Xử lý các sự kiện chuột cho trò chơi.
@@ -25,6 +26,22 @@ public class MouseHandler implements MouseListener, MouseWheelListener {
         }
         if (gp.keyH.isiPressed()) {
             return;
+        }
+        if (e.getButton() == MouseEvent.BUTTON1) {
+            int mouseX = e.getX();
+            int mouseY = e.getY();
+            int worldX = gp.getPlayer().getWorldX() - gp.getPlayer().getScreenX() + mouseX;
+            int worldY = gp.getPlayer().getWorldY() - gp.getPlayer().getScreenY() + mouseY;
+            OBJ_DroppedItem di = gp.getDroppedItemAt(worldX, worldY);
+            if (di != null) {
+                if (gp.getPlayer().getBag().canAdd(di.getItem())) {
+                    gp.getPlayer().addItem(di.getItem());
+                    gp.getDroppedItems().remove(di);
+                } else {
+                    gp.getUi().showMessage("Khung vật phẩm đầy");
+                }
+                return;
+            }
         }
             // Right mouse pressed
         if (e.getButton() == MouseEvent.BUTTON3) {

--- a/src/game/object/OBJ_DroppedItem.java
+++ b/src/game/object/OBJ_DroppedItem.java
@@ -1,0 +1,35 @@
+package game.object;
+
+import java.awt.Rectangle;
+import game.entity.item.Item;
+import game.main.GamePanel;
+import game.util.UtilityTool;
+
+/**
+ * Object đại diện cho item rơi trên mặt đất.
+ * Item biến mất sau một khoảng thời gian nếu không được nhặt.
+ */
+public class OBJ_DroppedItem extends SuperObject {
+    private static final long LIFETIME = 120_000; // 2 phút
+
+    private final Item item;
+    private final long spawnTime;
+
+    public OBJ_DroppedItem(Item item, int worldX, int worldY, GamePanel gp) {
+        this.item = item;
+        setWorldX(worldX);
+        setWorldY(worldY);
+        setCollisionArea(new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize()));
+        setImage(UtilityTool.scaleImage(item.getIcon(), gp.getTileSize(), gp.getTileSize()));
+        setScaleObjectWidth(1);
+        setScaleObjectHeight(1);
+        this.spawnTime = System.currentTimeMillis();
+    }
+
+    public Item getItem() { return item; }
+
+    /** Kiểm tra item đã hết thời gian tồn tại chưa. */
+    public boolean isExpired() {
+        return System.currentTimeMillis() - spawnTime > LIFETIME;
+    }
+}

--- a/src/game/ui/Ui.java
+++ b/src/game/ui/Ui.java
@@ -42,6 +42,7 @@ public class Ui {
     public void showMessage(String text) {
         message = text;
         messageOn = true;
+        messageCouter = 0;
     }
 
     public void draw(Graphics2D g2) {
@@ -67,6 +68,18 @@ public class Ui {
             g2.setColor(new Color(255, 0, 0, 100));
             g2.fillRect(0, 0, gp.getScreenWidth(), gp.getScreenHeight());
             damageCounter--;
+        }
+        if (messageOn) {
+            g2.setFont(g2.getFont().deriveFont(Font.PLAIN, 20F));
+            int x = gp.getScreenWidth() - g2.getFontMetrics().stringWidth(message) - 20;
+            int y = gp.getScreenHeight() / 3;
+            g2.setColor(Color.WHITE);
+            g2.drawString(message, x, y);
+            messageCouter++;
+            if (messageCouter > 180) {
+                messageOn = false;
+                messageCouter = 0;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- make monsters drop configured loot and spawn it on the ground
- allow players to click ground items to loot them and show a 3s message if inventory is full
- despawn dropped items after 2 minutes and document the new system

## Testing
- `javac -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68ad7eaec1fc832fb4f5cfe7e7de44c8