### PR TITLE
Fix equipment healing bug and profile parsing crash

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -81,4 +81,9 @@ Sửa lỗi và cải tiến:
 
 ## 1.0.19
 - Sửa lỗi tải thuộc tính khiến ATTACK/DEF bằng 0 và không gây sát thương lên quái vật.
-- Bug sử dụng trang bị hồi đầy máu
+- Phát hiện bug: mặc trang bị hồi đầy máu (đã sửa ở 1.0.20).
+
+## 1.0.20
+- Sửa lỗi mặc trang bị hồi đầy máu, HEALTH giữ nguyên khi thay đổi trang bị.
+- Bỏ qua chỉ số cộng thêm trong tệp lưu để tránh lỗi NumberFormatException khi tải hồ sơ.
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 ## Cập nhật
 
+## [1.0.20]
+
+### Sửa lỗi
+- Mặc trang bị không còn hồi đầy máu.
+- Tải hồ sơ bỏ qua chỉ số cộng thêm, tránh lỗi NumberFormatException.
+
 ## [1.0.19]
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -878,8 +878,21 @@ public class Player extends GameActor implements DrawableEntity {
                 if (idx >= 0) realmStage = Integer.parseInt(lower.substring(idx + 4).trim());
             }
 
+            boolean inEquipBlock = false;
             for (int i = 2; i < block.size(); i++) {
                 String line = block.get(i);
+
+                if (line.startsWith("Thuộc tính sau khi mặc đồ")) {
+                    inEquipBlock = true;
+                    continue;
+                }
+                if (inEquipBlock) {
+                    if (line.startsWith("--------------------------")) {
+                        inEquipBlock = false;
+                    }
+                    continue;
+                }
+
                 if (line.startsWith("HEALTH: ")) {
                     String val = line.substring(8).trim();
                     int cur, max;
@@ -893,7 +906,8 @@ public class Player extends GameActor implements DrawableEntity {
                     baseAtts.setMax(Attr.HEALTH, max);
                     baseAtts.set(Attr.HEALTH, cur);
                 } else if (line.startsWith("ATTACK: ")) {
-                    int v = Integer.parseInt(line.substring(8).trim());
+                    String val = line.substring(8).trim();
+                    int v = Integer.parseInt(val.split("\\s+")[0]);
                     baseAtts.set(Attr.ATTACK, v);
                 } else if (line.startsWith("PEP: ")) {
                     String val = line.substring(5).trim();
@@ -908,10 +922,12 @@ public class Player extends GameActor implements DrawableEntity {
                     baseAtts.setMax(Attr.PEP, max);
                     baseAtts.set(Attr.PEP, cur);
                 } else if (line.startsWith("DEF: ")) {
-                    int v = Integer.parseInt(line.substring(5).trim());
+                    String val = line.substring(5).trim();
+                    int v = Integer.parseInt(val.split("\\s+")[0]);
                     baseAtts.set(Attr.DEF, v);
                 } else if (line.startsWith("SOULD: ")) {
-                    int v = Integer.parseInt(line.substring(7).trim());
+                    String val = line.substring(7).trim();
+                    int v = Integer.parseInt(val.split("\\s+")[0]);
                     baseAtts.set(Attr.SOULD, v);
                 } else if (line.startsWith("SPIRIT: ")) {
                     String val = line.substring(8).trim();
@@ -933,7 +949,8 @@ public class Player extends GameActor implements DrawableEntity {
                     baseAtts.setMax(Attr.SPIRIT, spiritToNextLevel);
                     baseAtts.set(Attr.SPIRIT, 0);
                 } else if (line.startsWith("STRENGTH: ")) {
-                    int v = Integer.parseInt(line.substring(10).trim());
+                    String val = line.substring(10).trim();
+                    int v = Integer.parseInt(val.split("\\s+")[0]);
                     baseAtts.set(Attr.STRENGTH, v);
                 } else if (line.startsWith("PHYSIQUE: ")) {
                     physique = parsePhysique(line.substring(10).trim());
@@ -1159,6 +1176,10 @@ public class Player extends GameActor implements DrawableEntity {
     }
 
     private void refreshStats() {
+        int currentHealth = atts().get(Attr.HEALTH);
+        int currentPep = atts().get(Attr.PEP);
+        int currentSpirit = atts().get(Attr.SPIRIT);
+
         atts().setStarts(new EnumMap<>(baseAtts.getStarts()));
         for (Attr a : Attr.values()) {
             int max = baseAtts.getMax(a);
@@ -1176,6 +1197,10 @@ public class Player extends GameActor implements DrawableEntity {
                 default -> {}
             }
         }
+
+        atts().set(Attr.HEALTH, currentHealth);
+        atts().set(Attr.PEP, currentPep);
+        atts().set(Attr.SPIRIT, currentSpirit);
     }
 
     // -------- Equipment handling ---------


### PR DESCRIPTION
## Summary
- Prevent equipment changes from fully restoring player health
- Skip equipment bonus lines when loading profiles to avoid NumberFormatException
- Document equipment and profile loading fixes in changelog and README

## Testing
- `javac -d out @sources.txt`
- `java -cp bin TestLoad`


------
https://chatgpt.com/codex/tasks/task_e_68adac84b274832faa275794ba779c94