### PR TITLE
Fix health reset on equipment changes

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,0 +1,8 @@
+Max HP: 100
+HP after damage: 60
+HP after equip: 60
+HP after unequip: 60
+HP after potion: 100
+Equip keeps HP: true
+Unequip keeps HP: true
+Potion restores to max: true

--- a/Change.txt
+++ b/Change.txt
@@ -82,3 +82,9 @@ Sửa lỗi và cải tiến:
 ## 1.0.19
 - Sửa lỗi tải thuộc tính khiến ATTACK/DEF bằng 0 và không gây sát thương lên quái vật.
 - Bug sử dụng trang bị hồi đầy máu
+
+## 1.0.20
+- Sửa lỗi mặc trang bị làm hồi đầy máu.
+- Thêm hàm `takeDamage` và `heal` để đồng bộ máu gốc và hiện tại.
+- Quái vật tấn công và đan dược hồi máu sử dụng các hàm mới.
+- Bổ sung test tự động kiểm tra việc mặc trang bị không ảnh hưởng lượng máu hiện tại.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 ## Cập nhật
 
+## [1.0.20]
+
+### Sửa lỗi
+- Trang bị không còn làm hồi đầy máu; máu chỉ thay đổi khi nhận sát thương hoặc dùng đan dược.
+
 ## [1.0.19]
 
 ### Sửa lỗi

--- a/src/demo/EquipmentHealthTest.java
+++ b/src/demo/EquipmentHealthTest.java
@@ -1,0 +1,41 @@
+package demo;
+
+import game.enums.Attr;
+import game.enums.EquipSlot;
+import game.enums.EquipType;
+import game.entity.Player;
+import game.entity.item.EquipmentItem;
+import game.entity.item.elixir.HealthPotion;
+import game.main.GamePanel;
+
+/** Simple test to verify equipping items doesn't restore health. */
+public class EquipmentHealthTest {
+    public static void main(String[] args) {
+        GamePanel gp = new GamePanel();
+        Player p = gp.getPlayer();
+
+        int max = p.atts().getMax(Attr.HEALTH);
+        p.takeDamage(40);
+        int afterDamage = p.atts().get(Attr.HEALTH);
+
+        EquipmentItem armor = new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
+        p.equip(armor);
+        int afterEquip = p.atts().get(Attr.HEALTH);
+
+        p.unequip(EquipSlot.ARMOR);
+        int afterUnequip = p.atts().get(Attr.HEALTH);
+
+        HealthPotion pot = new HealthPotion(50, 1);
+        pot.use(p);
+        int afterPotion = p.atts().get(Attr.HEALTH);
+
+        System.out.println("Max HP: " + max);
+        System.out.println("HP after damage: " + afterDamage);
+        System.out.println("HP after equip: " + afterEquip);
+        System.out.println("HP after unequip: " + afterUnequip);
+        System.out.println("HP after potion: " + afterPotion);
+        System.out.println("Equip keeps HP: " + (afterEquip == afterDamage));
+        System.out.println("Unequip keeps HP: " + (afterUnequip == afterEquip));
+        System.out.println("Potion restores to max: " + (afterPotion == max));
+    }
+}

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -341,11 +341,33 @@ public class Player extends GameActor implements DrawableEntity {
                 }
             }
         }
-	
-	@Override
-	public void checkCollision() {
-		setCollisionOn(false);
-		gp.getCheckCollision().checkTile(this);
+
+    // -------- Health handling ---------
+
+    /**
+     * Gây sát thương cho người chơi, cập nhật cả chỉ số hiện tại và gốc.
+     *
+     * @param amount lượng sát thương nhận vào
+     */
+    public void takeDamage(int amount) {
+        atts().add(Attr.HEALTH, -amount);
+        baseAtts.add(Attr.HEALTH, -amount);
+    }
+
+    /**
+     * Hồi máu cho người chơi, đảm bảo không vượt quá giới hạn tối đa.
+     *
+     * @param amount lượng máu hồi
+     */
+    public void heal(int amount) {
+        atts().add(Attr.HEALTH, amount);
+        baseAtts.add(Attr.HEALTH, amount);
+    }
+
+        @Override
+        public void checkCollision() {
+                setCollisionOn(false);
+                gp.getCheckCollision().checkTile(this);
         gp.getCheckCollision().checkObject(this, false);
         gp.getCheckCollision().checkEntity(this, gp.getNpcs());
         int npcIndex = gp.getCheckCollision().checkInteraction(this, gp.getNpcs(), 48);
@@ -353,8 +375,7 @@ public class Player extends GameActor implements DrawableEntity {
 
         int monsterIndex = gp.getCheckCollision().checkEntity(this, gp.getMonsters());
         if (monsterIndex != 999 && !invincible) {
-            atts().add(Attr.HEALTH, -1);
-            baseAtts.add(Attr.HEALTH, -1);
+            takeDamage(1);
             gp.getUi().triggerDamageEffect();
             invincible = true;
         }

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -6,7 +6,6 @@ import javax.imageio.ImageIO;
 
 import game.entity.Player;
 import game.entity.item.Item;
-import game.enums.Attr;
 
 public class HealthPotion extends Item {
 	
@@ -32,12 +31,9 @@ public class HealthPotion extends Item {
 
 	@Override
     public void use(Player p) {
-        int current = p.atts().get(Attr.HEALTH);
-        int max = p.atts().getMax(Attr.HEALTH);
-        int newHealth = Math.min(current + healthAmount, max);
-        p.atts().set(Attr.HEALTH, newHealth);
+        p.heal(healthAmount);
         decreaseQuantity(1);
-}
+    }
 	
    @Override
     public Item copyWithQuantity(int qty) {

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -249,7 +249,7 @@ public abstract class Monster extends GameActor {
             gp.getPlayer().getCollisionArea().height
         );
         if (attackRect.intersects(playerRect)) {
-            gp.getPlayer().atts().add(Attr.HEALTH, -attackDamage);
+            gp.getPlayer().takeDamage(attackDamage);
             gp.getUi().triggerDamageEffect();
         }
         if (canAttackMonsters) {

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,8 @@
+Chạy các bước sau để kiểm tra:
+1. Biên dịch toàn bộ mã nguồn:
+   javac -d bin $(find src -name "*.java")
+2. Chạy chương trình kiểm tra:
+   java -cp bin demo.EquipmentHealthTest
+Kỳ vọng:
+- Sau khi bị trừ 40 máu rồi mặc/cởi trang bị, lượng máu vẫn giữ nguyên.
+- Uống đan dược hồi máu đưa máu về tối đa.


### PR DESCRIPTION
## Summary
- add Player.takeDamage and heal to keep base and current HP in sync
- make monsters and health potions use new health methods
- document fix and add regression test

## Testing
- `javac -d out @sources.txt`
- `java -cp bin demo.EquipmentHealthTest > AiTest.txt`

------
https://chatgpt.com/codex/tasks/task_e_68adbb0b3364832fba68e58c980c2253