### PR TITLE
Fix equipment healing bug

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,0 +1,3 @@
+Các trường hợp đã được AI kiểm thử:
+1. Mặc và tháo trang bị sau khi bị trừ máu/pep/spirit: máu (70), pep (80) và spirit (100) giữ nguyên trước và sau khi mặc.
+2. Uống đan dược hồi máu 50 điểm khi còn 50 máu: máu hồi đầy 100 như mong đợi.

--- a/Change.txt
+++ b/Change.txt
@@ -82,3 +82,6 @@ Sửa lỗi và cải tiến:
 ## 1.0.19
 - Sửa lỗi tải thuộc tính khiến ATTACK/DEF bằng 0 và không gây sát thương lên quái vật.
 - Bug sử dụng trang bị hồi đầy máu
+## 1.0.20
+- Sửa lỗi mặc hoặc tháo trang bị làm hồi đầy máu, pep hoặc spirit bằng cách giữ nguyên chỉ số hiện tại khi cập nhật thuộc tính.
+- Ghi lại các trường hợp kiểm thử trong AiTest.txt và hướng dẫn kiểm thử trong test.txt.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 ## Cập nhật
 
+## [1.0.20]
+
+### Sửa lỗi
+- Mặc hoặc tháo trang bị không còn hồi đầy máu, pep hay spirit của nhân vật.
+
 ## [1.0.19]
 
 ### Sửa lỗi

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -1159,6 +1159,12 @@ public class Player extends GameActor implements DrawableEntity {
     }
 
     private void refreshStats() {
+        // Preserve current dynamic stats so equipping items doesn't heal or grant pep/spirit
+        int curHealth = atts().getMax(Attr.HEALTH) > 0 ? atts().get(Attr.HEALTH) : baseAtts.get(Attr.HEALTH);
+        int curPep = atts().getMax(Attr.PEP) > 0 ? atts().get(Attr.PEP) : baseAtts.get(Attr.PEP);
+        int curSpirit = atts().getMax(Attr.SPIRIT) > 0 ? atts().get(Attr.SPIRIT) : baseAtts.get(Attr.SPIRIT);
+
+        // Reset stats to base values
         atts().setStarts(new EnumMap<>(baseAtts.getStarts()));
         for (Attr a : Attr.values()) {
             int max = baseAtts.getMax(a);
@@ -1168,6 +1174,8 @@ public class Player extends GameActor implements DrawableEntity {
                 atts().setMax(a, Integer.MAX_VALUE);
             }
         }
+
+        // Apply equipment bonuses
         for (EquipmentItem eq : equipment.values()) {
             switch (eq.getType()) {
                 case HELMET, ARMOR, SHOES, PANTS -> atts().add(Attr.DEF, 3);
@@ -1176,6 +1184,11 @@ public class Player extends GameActor implements DrawableEntity {
                 default -> {}
             }
         }
+
+        // Restore preserved dynamic stats, clamped to new maximums
+        atts().set(Attr.HEALTH, Math.min(curHealth, atts().getMax(Attr.HEALTH)));
+        atts().set(Attr.PEP, Math.min(curPep, atts().getMax(Attr.PEP)));
+        atts().set(Attr.SPIRIT, Math.min(curSpirit, atts().getMax(Attr.SPIRIT)));
     }
 
     // -------- Equipment handling ---------

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,4 @@
+Các trường hợp đề nghị bạn tự kiểm thử:
+1. Trang bị và tháo nhiều loại item khác nhau sau khi nhân vật mất máu để đảm bảo chỉ số không thay đổi.
+2. Sử dụng đan dược hồi máu khi đang mặc trang bị để xác nhận vẫn hồi đúng lượng máu.
+3. Kiểm tra pep và spirit khi sử dụng kỹ năng hoặc tu luyện, bảo đảm việc mặc trang bị không làm thay đổi các chỉ số này.


### PR DESCRIPTION
## Summary
- keep current HEALTH/PEP/SPIRIT when equipping or removing gear
- document the fix and add test instructions

## Testing
- `java -cp bin:/tmp EquipHealthTest`
- `java -cp bin:/tmp HealthPotionTest`


------
https://chatgpt.com/codex/tasks/task_e_68adbb0cdc2c832f8cecdcb4ac6f11e3