### PR TITLE
Fix equipment no longer restores health or pep

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,0 +1,3 @@
+Da kiem thu cac truong hop sau:
+1. Giam mau va pep roi mac trang bi, cac chi so khong doi.
+2. Su dung dan duoc hoi mau, mac trang bi khong lam mat mau da hoi.

--- a/Change.txt
+++ b/Change.txt
@@ -82,3 +82,7 @@ Sửa lỗi và cải tiến:
 ## 1.0.19
 - Sửa lỗi tải thuộc tính khiến ATTACK/DEF bằng 0 và không gây sát thương lên quái vật.
 - Bug sử dụng trang bị hồi đầy máu
+
+## 1.0.20
+- Khắc phục bug mặc trang bị hồi đầy máu; HEALTH, PEP và SPIRIT giữ nguyên khi thay trang bị.
+- Đan dược hồi máu cập nhật cả thuộc tính gốc để tránh bị đặt lại khi mặc trang bị.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 ## Cập nhật
 
+## [1.0.20]
+
+### Sửa lỗi
+- Trang bị không còn hồi đầy máu hay pep; chỉ đan dược mới có thể hồi các chỉ số này.
+- Đan dược hồi máu đồng bộ với máu gốc để tránh bị đặt lại khi mặc trang bị.
+
 ## [1.0.19]
 
 ### Sửa lỗi

--- a/src/demo/PlayerEquipTest.java
+++ b/src/demo/PlayerEquipTest.java
@@ -1,0 +1,55 @@
+package demo;
+
+import game.main.GamePanel;
+import game.entity.Player;
+import game.entity.item.EquipmentItem;
+import game.entity.item.elixir.HealthPotion;
+import game.enums.Attr;
+import game.enums.EquipType;
+import java.nio.file.*;
+
+public class PlayerEquipTest {
+    public static void main(String[] args) {
+        Path save = Paths.get("player.Nguyeen_pro.20250826.txt");
+        Path backup = Paths.get("player.Nguyeen_pro.20250826.txt.bak");
+        try {
+            if (Files.exists(save)) {
+                Files.move(save, backup, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            GamePanel gp = new GamePanel();
+            Player p = gp.getPlayer();
+
+        // Giảm máu và pep rồi mặc trang bị
+        p.atts().add(Attr.HEALTH, -30);
+        p.atts().add(Attr.PEP, -20);
+        int hp = p.atts().get(Attr.HEALTH);
+        int pep = p.atts().get(Attr.PEP);
+        int spirit = p.atts().get(Attr.SPIRIT);
+
+        p.equip(new EquipmentItem("Mũ sắt", "+3 DEF", "", EquipType.HELMET));
+
+        assert p.atts().get(Attr.HEALTH) == hp : "Equip should not restore health";
+        assert p.atts().get(Attr.PEP) == pep : "Equip should not restore pep";
+        assert p.atts().get(Attr.SPIRIT) == spirit : "Equip should not change spirit";
+
+        // Sử dụng đan dược hồi máu rồi mặc trang bị để kiểm tra không bị mất máu
+        p.atts().add(Attr.HEALTH, -20); // gây thêm sát thương
+        HealthPotion pot = new HealthPotion(50, 1);
+        pot.use(p);
+        int healed = p.atts().get(Attr.HEALTH);
+        p.equip(new EquipmentItem("Giày", "+3 DEF", "", EquipType.SHOES));
+        assert p.atts().get(Attr.HEALTH) == healed : "Equip should keep healed health";
+
+            System.out.println("All tests passed.");
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (Files.exists(backup)) {
+                    Files.move(backup, save, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (Exception ignored) {}
+        }
+    }
+}

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -1159,6 +1159,12 @@ public class Player extends GameActor implements DrawableEntity {
     }
 
     private void refreshStats() {
+        // Lưu lại các giá trị động trước khi làm mới
+        int curHealth = atts().get(Attr.HEALTH);
+        int curPep = atts().get(Attr.PEP);
+        int curSpirit = atts().get(Attr.SPIRIT);
+
+        // Sao chép chỉ số gốc làm nền tảng
         atts().setStarts(new EnumMap<>(baseAtts.getStarts()));
         for (Attr a : Attr.values()) {
             int max = baseAtts.getMax(a);
@@ -1168,6 +1174,8 @@ public class Player extends GameActor implements DrawableEntity {
                 atts().setMax(a, Integer.MAX_VALUE);
             }
         }
+
+        // Cộng thêm chỉ số từ trang bị
         for (EquipmentItem eq : equipment.values()) {
             switch (eq.getType()) {
                 case HELMET, ARMOR, SHOES, PANTS -> atts().add(Attr.DEF, 3);
@@ -1176,6 +1184,15 @@ public class Player extends GameActor implements DrawableEntity {
                 default -> {}
             }
         }
+
+        // Phục hồi lại HEALTH/PEP/SPIRIT và đồng bộ với baseAtts
+        atts().set(Attr.HEALTH, Math.min(curHealth, atts().getMax(Attr.HEALTH)));
+        atts().set(Attr.PEP, Math.min(curPep, atts().getMax(Attr.PEP)));
+        atts().set(Attr.SPIRIT, Math.min(curSpirit, atts().getMax(Attr.SPIRIT)));
+
+        baseAtts.set(Attr.HEALTH, atts().get(Attr.HEALTH));
+        baseAtts.set(Attr.PEP, atts().get(Attr.PEP));
+        baseAtts.set(Attr.SPIRIT, atts().get(Attr.SPIRIT));
     }
 
     // -------- Equipment handling ---------
@@ -1213,5 +1230,6 @@ public class Player extends GameActor implements DrawableEntity {
     public int getScreenY() { return screenY; }
 
     public static int getInteractionRange() { return INTERACTION_RANGE; }
+    public Attributes baseAtts() { return baseAtts; }
     public Inventory getBag() { return bag; }
 }

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -36,6 +36,8 @@ public class HealthPotion extends Item {
         int max = p.atts().getMax(Attr.HEALTH);
         int newHealth = Math.min(current + healthAmount, max);
         p.atts().set(Attr.HEALTH, newHealth);
+        // Đồng bộ máu gốc để tránh trang bị làm thay đổi máu
+        p.baseAtts().set(Attr.HEALTH, newHealth);
         decreaseQuantity(1);
 }
 	

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,5 @@
+Vui long tu kiem tra cac truong hop:
+1. Gay sat thuong cho nhan vat, mac va go bo trang bi de dam bao mau khong bi thay doi.
+2. Uong dan duoc hoi mau sau khi bi thuong, mac trang bi xem mau co giu nguyen.
+3. Su dung ky nang de tieu hao Pep, sau do mac trang bi va kiem tra Pep khong duoc hoi.
+4. Dam bao kinh nghiem (Spirit) chi tang khi tu luyen, mac trang bi khong anh huong.


### PR DESCRIPTION
## Summary
- Preserve current HEALTH, PEP and SPIRIT when equipping or unequipping items
- Sync base attributes when using health potions to avoid reset by equipment
- Document bug fix and add demo test for equipment behavior

## Testing
- `javac -cp bin -d bin src/game/entity/Player.java src/game/entity/item/elixir/HealthPotion.java src/demo/PlayerEquipTest.java`
- `java -ea -cp bin demo.PlayerEquipTest`


------
https://chatgpt.com/codex/tasks/task_e_68adbb0e9780832f9c3162e469ca4d11