### PR TITLE
Normalize player persistence and stats

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,0 +1,1 @@
+Compiled all Java source files with `javac $(find src -name "*.java")` to ensure build succeeds.

--- a/Change.txt
+++ b/Change.txt
@@ -103,3 +103,6 @@ Sửa lỗi và cải tiến:
   `EnumMap<Attr,Integer>` mô tả chỉ số cộng thêm.
 - Refactor `Attributes` sử dụng lớp `Stat` hỗ trợ giá trị gốc và cộng thêm;
   `Player.refreshStats()` cộng dồn bonus từ trang bị.
+## 1.0.24
+- Mỗi `Item` mang mã `id`, kho đồ lưu được cả tiêu hao và vật liệu.
+- Thêm `ItemTemplateDAO` và `ItemGenerator` tạo trang bị ngẫu nhiên từ mẫu.

--- a/Change.txt
+++ b/Change.txt
@@ -95,3 +95,11 @@ Sửa lỗi và cải tiến:
 - Đổi tên cột `Percent` thành `PercentBonus` trong `sql/game_db_core_schema.sql` để tránh từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa có.
 - Cập nhật README hướng dẫn chạy script trước khi khởi động game.
+
+## 1.0.23
+- Thay thế lưu hồ sơ dạng chuỗi bằng các bảng chuẩn hóa `Players`, `PlayerBaseStats`,
+  `PlayerRuntime`, `PlayerInventory` và `PlayerEquipment` thông qua `PlayerDAO`.
+- Thêm `ItemDAO` tải định nghĩa vật phẩm và các `ItemStatMods` để tạo `EquipmentItem` có
+  `EnumMap<Attr,Integer>` mô tả chỉ số cộng thêm.
+- Refactor `Attributes` sử dụng lớp `Stat` hỗ trợ giá trị gốc và cộng thêm;
+  `Player.refreshStats()` cộng dồn bonus từ trang bị.

--- a/ItemAndStatGuide.md
+++ b/ItemAndStatGuide.md
@@ -1,0 +1,13 @@
+# Hướng dẫn thêm trang bị và chỉ số mới
+
+## Thêm trang bị mới
+1. Thêm dòng vào bảng `Items` với `ItemId`, `Name` và `Type` (ví dụ `WEAPON`, `ARMOR`, `HEALTH_POTION`...).
+2. Nếu là trang bị, khai báo các chỉ số cơ bản tại bảng `ItemStatMods` bằng cách tạo bản ghi mới cho từng thuộc tính (`Stat`, `Flat`).
+3. Nếu muốn trang bị rơi ngẫu nhiên, sử dụng `ItemGenerator.createFromTemplate` với `ItemId` của mẫu vừa tạo.
+
+## Thêm chỉ số mới
+1. Thêm hằng mới vào enum `game.enums.Attr`.
+2. Cập nhật bảng `PlayerBaseStats` và các bảng liên quan trong `sql/game_db_core_schema.sql` nếu cần lưu vào cơ sở dữ liệu.
+3. Các lớp `Attributes`, `Player.refreshStats()` và những nơi tính toán khác có thể cần điều chỉnh để sử dụng thuộc tính mới.
+
+Xem `README.md` để biết thêm thông tin chi tiết.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@
 - Đổi tên cột `ItemStatMods.Percent` thành `PercentBonus` để tránh xung đột từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa tồn tại.
 
+## [1.0.23]
+
+### Thay đổi
+- Hồ sơ người chơi được lưu vào các bảng chuẩn hóa (`Players`, `PlayerBaseStats`,
+  `PlayerRuntime`, `PlayerInventory`, `PlayerEquipment`).
+- Thêm `PlayerDAO` và `ItemDAO` để đọc/ghi dữ liệu từ SQL Server.
+- `EquipmentItem` mang `EnumMap<Attr,Integer>` mô tả bonus; `Attributes` tách giá trị gốc
+  và cộng thêm bằng lớp `Stat`.
+
 ## [1.0.20]
 
 ### Thêm
@@ -162,9 +171,8 @@
 ## Cách chạy
 
 1. Chạy script `sql/game_db_core_schema.sql` trên SQL Server để tạo database và dữ liệu mẫu.
-2. Chạy script `sql/create_player_profile.sql` để đảm bảo bảng `PlayerProfile` tồn tại.
-3. Mở project trong Eclipse.
-4. Chạy class `Main.java` bằng cách click chuột phải → Run As → Java Application.
+2. Mở project trong Eclipse.
+3. Chạy class `Main.java` bằng cách click chuột phải → Run As → Java Application.
 
 ## Yêu cầu hệ thống
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@
 - `EquipmentItem` mang `EnumMap<Attr,Integer>` mô tả bonus; `Attributes` tách giá trị gốc
   và cộng thêm bằng lớp `Stat`.
 
+## [1.0.24]
+
+### Thêm
+- `ItemTemplateDAO` và `ItemGenerator` tạo trang bị ngẫu nhiên từ mẫu trong SQL.
+- Mọi `Item` đều có `id` riêng, kho đồ lưu được cả tiêu hao và vật liệu.
+- Xem thêm `ItemAndStatGuide.md` để mở rộng trang bị và chỉ số.
+
 ## [1.0.20]
 
 ### Thêm

--- a/src/game/db/ItemDAO.java
+++ b/src/game/db/ItemDAO.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 import game.entity.item.EquipmentItem;
 import game.entity.item.Item;
+import game.entity.item.MaterialItem;
+import game.entity.item.elixir.HealthPotion;
+import game.entity.item.elixir.SpiritPotion;
 import game.enums.Attr;
 import game.enums.EquipType;
 
@@ -38,16 +41,32 @@ public class ItemDAO {
                 if (!rs.next()) return null;
                 String name = rs.getString("Name");
                 String type = rs.getString("Type");
-                EquipType eType = parseEquipType(type);
-                if (eType == null) {
-                    return null; // unsupported for now
-                }
-                EnumMap<Attr, Integer> bonuses = loadBonuses(conn, itemId);
-                String icon = defaultIcon(eType);
-                return new EquipmentItem(itemId, name, "", icon, eType, bonuses);
-            }
-        }
-    }
+                  EnumMap<Attr, Integer> bonuses = loadBonuses(conn, itemId);
+                  EquipType eType = parseEquipType(type);
+                  if (eType != null) {
+                      String icon = defaultIcon(eType);
+                      return new EquipmentItem(itemId, name, "", icon, eType, bonuses);
+                  }
+                  String t = type == null ? "" : type.trim().toUpperCase();
+                  switch (t) {
+                      case "HEALTH_POTION" -> {
+                          int heal = bonuses.getOrDefault(Attr.HEALTH, 0);
+                          return new HealthPotion(itemId, heal, 1);
+                      }
+                      case "SPIRIT_POTION" -> {
+                          int amount = bonuses.getOrDefault(Attr.SPIRIT, 0);
+                          return new SpiritPotion(itemId, amount, 1);
+                      }
+                      case "MATERIAL" -> {
+                          return new MaterialItem(itemId, name, "", null, 1, 99);
+                      }
+                      default -> {
+                          return null; // unsupported type
+                      }
+                  }
+              }
+          }
+      }
 
     private static EnumMap<Attr, Integer> loadBonuses(Connection conn, String itemId) throws SQLException {
         EnumMap<Attr, Integer> map = new EnumMap<>(Attr.class);

--- a/src/game/db/ItemDAO.java
+++ b/src/game/db/ItemDAO.java
@@ -1,0 +1,93 @@
+package game.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
+
+import game.entity.item.EquipmentItem;
+import game.entity.item.Item;
+import game.enums.Attr;
+import game.enums.EquipType;
+
+/**
+ * Data access helper for items and their stat modifiers.
+ */
+public class ItemDAO {
+
+    private static final String ITEMS = "Items";
+    private static final String ITEM_MODS = "ItemStatMods";
+
+    private ItemDAO() {}
+
+    /**
+     * Load an item by id. Supports equipment types; other item types are
+     * returned as null.
+     *
+     * @param itemId identifier in the {@code Items} table
+     * @return constructed {@link Item} or {@code null} if not found/unsupported
+     */
+    public static Item load(String itemId) throws SQLException, ClassNotFoundException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT Name, Type FROM " + ITEMS + " WHERE ItemId = ?");
+            ps.setString(1, itemId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) return null;
+                String name = rs.getString("Name");
+                String type = rs.getString("Type");
+                EquipType eType = parseEquipType(type);
+                if (eType == null) {
+                    return null; // unsupported for now
+                }
+                EnumMap<Attr, Integer> bonuses = loadBonuses(conn, itemId);
+                String icon = defaultIcon(eType);
+                return new EquipmentItem(itemId, name, "", icon, eType, bonuses);
+            }
+        }
+    }
+
+    private static EnumMap<Attr, Integer> loadBonuses(Connection conn, String itemId) throws SQLException {
+        EnumMap<Attr, Integer> map = new EnumMap<>(Attr.class);
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT Stat, Flat FROM " + ITEM_MODS + " WHERE ItemId = ?");
+        ps.setString(1, itemId);
+        try (ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                String stat = rs.getString("Stat");
+                try {
+                    Attr attr = Attr.valueOf(stat);
+                    int val = rs.getInt("Flat");
+                    map.put(attr, val);
+                } catch (IllegalArgumentException ex) {
+                    // unknown stat, ignore
+                }
+            }
+        }
+        return map;
+    }
+
+    private static EquipType parseEquipType(String type) {
+        if (type == null) return null;
+        try {
+            return EquipType.valueOf(type.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String defaultIcon(EquipType type) {
+        return switch (type) {
+            case ARMOR -> "/data/item/equipment/armor.png";
+            case HELMET -> "/data/item/equipment/helmet.png";
+            case PANTS -> "/data/item/equipment/pants.png";
+            case SHOES -> "/data/item/equipment/shoes.png";
+            case NECKLACE, RING -> "/data/item/equipment/ring.png";
+            case WEAPON -> "/data/item/equipment/sword.png";
+            case AMULET -> "/data/item/equipment/d_1.png";
+        };
+    }
+}
+

--- a/src/game/db/ItemTemplateDAO.java
+++ b/src/game/db/ItemTemplateDAO.java
@@ -1,0 +1,68 @@
+package game.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.EnumMap;
+
+import game.entity.item.ItemTemplate;
+import game.enums.Attr;
+import game.enums.EquipType;
+
+/**
+ * DAO for loading equipment templates from the database.
+ */
+public class ItemTemplateDAO {
+    private static final String ITEMS = "Items";
+    private static final String ITEM_MODS = "ItemStatMods";
+
+    private ItemTemplateDAO() {}
+
+    /**
+     * Load a template by its identifier.
+     */
+    public static ItemTemplate load(String templateId) throws SQLException, ClassNotFoundException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT Name, Type FROM " + ITEMS + " WHERE ItemId=?");
+            ps.setString(1, templateId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) return null;
+                String name = rs.getString("Name");
+                EquipType type = parseEquipType(rs.getString("Type"));
+                EnumMap<Attr, Integer> bonuses = loadBonuses(conn, templateId);
+                return new ItemTemplate(templateId, name, type, bonuses);
+            }
+        }
+    }
+
+    private static EnumMap<Attr, Integer> loadBonuses(Connection conn, String itemId) throws SQLException {
+        EnumMap<Attr, Integer> map = new EnumMap<>(Attr.class);
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT Stat, Flat FROM " + ITEM_MODS + " WHERE ItemId = ?");
+        ps.setString(1, itemId);
+        try (ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                String stat = rs.getString("Stat");
+                try {
+                    Attr attr = Attr.valueOf(stat);
+                    int val = rs.getInt("Flat");
+                    map.put(attr, val);
+                } catch (IllegalArgumentException ex) {
+                    // ignore unknown stat
+                }
+            }
+        }
+        return map;
+    }
+
+    private static EquipType parseEquipType(String type) {
+        if (type == null) return null;
+        try {
+            return EquipType.valueOf(type.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/game/db/PlayerDAO.java
+++ b/src/game/db/PlayerDAO.java
@@ -1,0 +1,241 @@
+package game.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import game.entity.Player;
+import game.entity.item.EquipmentItem;
+import game.entity.item.Item;
+import game.entity.inventory.Inventory;
+import game.enums.Attr;
+import game.enums.EquipSlot;
+import game.entity.attributes.Attributes;
+
+/**
+ * DAO helper for persisting {@link Player} state into normalized tables.
+ */
+public class PlayerDAO {
+    private static final String PLAYERS = "Players";
+    private static final String BASE = "PlayerBaseStats";
+    private static final String RUNTIME = "PlayerRuntime";
+    private static final String INV = "PlayerInventory";
+    private static final String EQUIP = "PlayerEquipment";
+
+    private PlayerDAO() {}
+
+    /**
+     * Load player state from database into {@code p}.
+     *
+     * @return true if data existed; false otherwise
+     */
+    public static boolean load(Player p) {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT PlayerId, Realm FROM " + PLAYERS + " WHERE Name=?");
+            ps.setString(1, p.getName());
+            ResultSet rs = ps.executeQuery();
+            if (!rs.next()) return false;
+            String playerId = rs.getString("PlayerId");
+            // Realm could be stored but Player currently keeps default; ignore for brevity
+
+            loadBaseStats(conn, playerId, p.getBaseAttributes());
+            loadRuntime(conn, playerId, p.getBaseAttributes());
+            loadInventory(conn, playerId, p.getBag());
+            loadEquipment(conn, playerId, p);
+            p.refreshStats();
+            return true;
+        } catch (ClassNotFoundException | SQLException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private static void loadBaseStats(Connection conn, String pid, Attributes atts) throws SQLException {
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength FROM " + BASE + " WHERE PlayerId=?");
+        ps.setString(1, pid);
+        ResultSet rs = ps.executeQuery();
+        if (rs.next()) {
+            atts.setBase(Attr.ATTACK, rs.getInt("Atk"));
+            atts.set(Attr.ATTACK, rs.getInt("Atk"));
+            atts.setBase(Attr.DEF, rs.getInt("Def"));
+            atts.set(Attr.DEF, rs.getInt("Def"));
+            atts.setBase(Attr.SOULD, rs.getInt("Sould"));
+            atts.set(Attr.SOULD, rs.getInt("Sould"));
+            atts.setBase(Attr.STRENGTH, rs.getInt("Strength"));
+            atts.set(Attr.STRENGTH, rs.getInt("Strength"));
+            atts.setBase(Attr.SPIRIT, rs.getInt("Spirit"));
+            atts.set(Attr.SPIRIT, rs.getInt("Spirit"));
+            atts.setMax(Attr.HEALTH, rs.getInt("HealthMax"));
+            atts.setMax(Attr.PEP, rs.getInt("PepMax"));
+            atts.setMax(Attr.SPIRIT, rs.getInt("SpiritMax"));
+        }
+    }
+
+    private static void loadRuntime(Connection conn, String pid, Attributes atts) throws SQLException {
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT CurrentHP, CurrentPep FROM " + RUNTIME + " WHERE PlayerId=?");
+        ps.setString(1, pid);
+        ResultSet rs = ps.executeQuery();
+        if (rs.next()) {
+            atts.set(Attr.HEALTH, rs.getInt("CurrentHP"));
+            atts.set(Attr.PEP, rs.getInt("CurrentPep"));
+        }
+    }
+
+    private static void loadInventory(Connection conn, String pid, Inventory bag) throws SQLException, ClassNotFoundException {
+        bag.clear();
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT ItemId, Quantity FROM " + INV + " WHERE PlayerId=?");
+        ps.setString(1, pid);
+        ResultSet rs = ps.executeQuery();
+        while (rs.next()) {
+            String itemId = rs.getString("ItemId");
+            int qty = rs.getInt("Quantity");
+            Item item = ItemDAO.load(itemId);
+            if (item != null) {
+                item.setQuantity(qty);
+                bag.add(item);
+            }
+        }
+    }
+
+    private static void loadEquipment(Connection conn, String pid, Player p) throws SQLException, ClassNotFoundException {
+        for (EquipSlot slot : EquipSlot.values()) {
+            p.getEquipmentMap().remove(slot);
+        }
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT Slot, ItemId FROM " + EQUIP + " WHERE PlayerId=?");
+        ps.setString(1, pid);
+        ResultSet rs = ps.executeQuery();
+        while (rs.next()) {
+            String slotName = rs.getString("Slot");
+            String itemId = rs.getString("ItemId");
+            try {
+                EquipSlot slot = EquipSlot.valueOf(slotName);
+                if (itemId != null && !itemId.isBlank()) {
+                    Item it = ItemDAO.load(itemId);
+                    if (it instanceof EquipmentItem eq) {
+                        p.getEquipmentMap().put(slot, eq);
+                        if (eq.getType().name().equals("RING")) {
+                            p.getBag().increaseCapacity(10);
+                        }
+                    }
+                }
+            } catch (IllegalArgumentException ignore) { }
+        }
+    }
+
+    /** Persist current state of {@code p} into the database. */
+    public static void save(Player p) {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            conn.setAutoCommit(false);
+            String playerId = upsertPlayer(conn, p);
+            saveBaseStats(conn, playerId, p.getBaseAttributes());
+            saveRuntime(conn, playerId, p.getBaseAttributes());
+            saveInventory(conn, playerId, p.getBag());
+            saveEquipment(conn, playerId, p);
+            conn.commit();
+        } catch (ClassNotFoundException | SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String upsertPlayer(Connection conn, Player p) throws SQLException {
+        String playerId = null;
+        PreparedStatement sel = conn.prepareStatement("SELECT PlayerId FROM " + PLAYERS + " WHERE Name=?");
+        sel.setString(1, p.getName());
+        ResultSet rs = sel.executeQuery();
+        if (rs.next()) {
+            playerId = rs.getString(1);
+            PreparedStatement upd = conn.prepareStatement("UPDATE " + PLAYERS + " SET Realm=? WHERE PlayerId=?");
+            upd.setString(1, p.getRealm().name());
+            upd.setString(2, playerId);
+            upd.executeUpdate();
+        } else {
+            PreparedStatement ins = conn.prepareStatement(
+                "INSERT INTO " + PLAYERS + " (Name, Realm) VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS);
+            ins.setString(1, p.getName());
+            ins.setString(2, p.getRealm().name());
+            ins.executeUpdate();
+            // Retrieve generated id
+            rs = sel.executeQuery();
+            if (rs.next()) {
+                playerId = rs.getString(1);
+            }
+        }
+        return playerId;
+    }
+
+    private static void saveBaseStats(Connection conn, String pid, Attributes atts) throws SQLException {
+        PreparedStatement del = conn.prepareStatement("DELETE FROM " + BASE + " WHERE PlayerId=?");
+        del.setString(1, pid);
+        del.executeUpdate();
+        PreparedStatement ins = conn.prepareStatement(
+            "INSERT INTO " + BASE + " (PlayerId, Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength) VALUES (?,?,?,?,?,?,?,?,?)");
+        ins.setString(1, pid);
+        ins.setInt(2, atts.getBase(Attr.ATTACK));
+        ins.setInt(3, atts.getBase(Attr.DEF));
+        ins.setInt(4, atts.getMax(Attr.HEALTH));
+        ins.setInt(5, atts.getMax(Attr.PEP));
+        ins.setInt(6, atts.getBase(Attr.SOULD));
+        ins.setInt(7, atts.get(Attr.SPIRIT));
+        ins.setInt(8, atts.getMax(Attr.SPIRIT));
+        ins.setInt(9, atts.getBase(Attr.STRENGTH));
+        ins.executeUpdate();
+    }
+
+    private static void saveRuntime(Connection conn, String pid, Attributes atts) throws SQLException {
+        PreparedStatement del = conn.prepareStatement("DELETE FROM " + RUNTIME + " WHERE PlayerId=?");
+        del.setString(1, pid);
+        del.executeUpdate();
+        PreparedStatement ins = conn.prepareStatement(
+            "INSERT INTO " + RUNTIME + " (PlayerId, CurrentHP, CurrentPep, Money) VALUES (?,?,?,?)");
+        ins.setString(1, pid);
+        ins.setInt(2, atts.get(Attr.HEALTH));
+        ins.setInt(3, atts.get(Attr.PEP));
+        ins.setLong(4, 0); // money not tracked in Player yet
+        ins.executeUpdate();
+    }
+
+    private static void saveInventory(Connection conn, String pid, Inventory bag) throws SQLException {
+        PreparedStatement del = conn.prepareStatement("DELETE FROM " + INV + " WHERE PlayerId=?");
+        del.setString(1, pid);
+        del.executeUpdate();
+        PreparedStatement ins = conn.prepareStatement(
+            "INSERT INTO " + INV + " (PlayerId, ItemId, Quantity) VALUES (?,?,?)");
+        for (Item it : bag.all()) {
+            if (it instanceof EquipmentItem eq) {
+                ins.setString(1, pid);
+                ins.setString(2, eq.getId());
+                ins.setInt(3, it.getQuantity());
+                ins.addBatch();
+            }
+        }
+        ins.executeBatch();
+    }
+
+    private static void saveEquipment(Connection conn, String pid, Player p) throws SQLException {
+        PreparedStatement del = conn.prepareStatement("DELETE FROM " + EQUIP + " WHERE PlayerId=?");
+        del.setString(1, pid);
+        del.executeUpdate();
+        PreparedStatement ins = conn.prepareStatement(
+            "INSERT INTO " + EQUIP + " (PlayerId, Slot, ItemId) VALUES (?,?,?)");
+        for (EquipSlot slot : EquipSlot.values()) {
+            EquipmentItem eq = p.getEquipment(slot);
+            ins.setString(1, pid);
+            ins.setString(2, slot.name());
+            if (eq != null) {
+                ins.setString(3, eq.getId());
+            } else {
+                ins.setNull(3, java.sql.Types.NVARCHAR);
+            }
+            ins.addBatch();
+        }
+        ins.executeBatch();
+    }
+}
+

--- a/src/game/db/PlayerDAO.java
+++ b/src/game/db/PlayerDAO.java
@@ -208,12 +208,10 @@ public class PlayerDAO {
         PreparedStatement ins = conn.prepareStatement(
             "INSERT INTO " + INV + " (PlayerId, ItemId, Quantity) VALUES (?,?,?)");
         for (Item it : bag.all()) {
-            if (it instanceof EquipmentItem eq) {
-                ins.setString(1, pid);
-                ins.setString(2, eq.getId());
-                ins.setInt(3, it.getQuantity());
-                ins.addBatch();
-            }
+            ins.setString(1, pid);
+            ins.setString(2, it.getId());
+            ins.setInt(3, it.getQuantity());
+            ins.addBatch();
         }
         ins.executeBatch();
     }

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -156,24 +156,24 @@ public class Player extends GameActor implements DrawableEntity {
             baseAtts.set(Attr.SPIRIT, 0);
 
             // Thêm vài item test: bình hồi máu & tinh thần
-            addItem(new game.entity.item.elixir.HealthPotion(50, 3));
-            addItem(new game.entity.item.elixir.SpiritPotion(200, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion(2000, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion(20000, 100));
+            addItem(new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3));
+            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100));
+            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100));
+            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100));
 
             // Các sách công pháp và đan dược tu luyện để thử nghiệm
             var low = new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1);
             var mid = new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 2);
             var high = new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 3);
             var top = new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 5);
-            addItem(new game.entity.item.book.CultivationBook(low));
-            addItem(new game.entity.item.book.CultivationBook(mid));
-            addItem(new game.entity.item.book.CultivationBook(high));
-            addItem(new game.entity.item.book.CultivationBook(top));
-            addItem(new game.entity.item.elixir.CultivationPill("Đan hạ phẩm", 1, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("Đan trung phẩm", 2, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("Đan thượng phẩm", 3, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("Đan cực phẩm", 4, 1));
+            addItem(new game.entity.item.book.CultivationBook("BOOK_LOW", low));
+            addItem(new game.entity.item.book.CultivationBook("BOOK_MID", mid));
+            addItem(new game.entity.item.book.CultivationBook("BOOK_HIGH", high));
+            addItem(new game.entity.item.book.CultivationBook("BOOK_TOP", top));
+            addItem(new game.entity.item.elixir.CultivationPill("PILL_LOW", "Đan hạ phẩm", 1, 1));
+            addItem(new game.entity.item.elixir.CultivationPill("PILL_MID", "Đan trung phẩm", 2, 1));
+            addItem(new game.entity.item.elixir.CultivationPill("PILL_HIGH", "Đan thượng phẩm", 3, 1));
+            addItem(new game.entity.item.elixir.CultivationPill("PILL_TOP", "Đan cực phẩm", 4, 1));
             
             EquipmentItem armor = new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
             armor.setBonus(Attr.DEF, 3);

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -5,7 +5,6 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
-import java.sql.*;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,7 +16,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
-import java.util.Arrays;
 
 import javax.imageio.ImageIO;
 
@@ -43,7 +41,7 @@ import game.entity.skill.CultivationTechnique;
 import game.main.GamePanel;
 import game.util.CameraHelper;
 import game.util.UtilityTool;
-import game.db.DBAccount;
+import game.db.PlayerDAO;
 
 public class Player extends GameActor implements DrawableEntity {
 	// Vị trí nhân vật trên màn hình (luôn ở giữa)
@@ -51,9 +49,6 @@ public class Player extends GameActor implements DrawableEntity {
     private final int screenY;
     
     private static final int INTERACTION_RANGE = 80;
-
-    /** Database table storing serialized player profiles. */
-    private static final String PROFILE_TABLE = "PlayerProfile";
 
     private final Inventory bag = new Inventory();
     private final EnumMap<EquipSlot, EquipmentItem> equipment = new EnumMap<>(EquipSlot.class);
@@ -131,16 +126,22 @@ public class Player extends GameActor implements DrawableEntity {
         setSpriteNum(1);
         setName("Nguyeen pro2o");
 
-        if (!loadProfile()) {
+        if (!PlayerDAO.load(this)) {
             // Thuộc tính cơ bản
+            baseAtts.setBase(Attr.HEALTH, 100);
             baseAtts.setMax(Attr.HEALTH, 100);
             baseAtts.set(Attr.HEALTH, 100);
+            baseAtts.setBase(Attr.PEP, 100);
             baseAtts.setMax(Attr.PEP, 100);
             baseAtts.set(Attr.PEP, 100);
             // Attack/Def không còn giới hạn max mặc định để có thể tăng khi lên cấp
+            baseAtts.setBase(Attr.ATTACK, 5);
             baseAtts.set(Attr.ATTACK, 5);
+            baseAtts.setBase(Attr.DEF, 4);
             baseAtts.set(Attr.DEF, 4);
+            baseAtts.setBase(Attr.STRENGTH, 1);
             baseAtts.set(Attr.STRENGTH, 1);
+            baseAtts.setBase(Attr.SOULD, 5);
             baseAtts.set(Attr.SOULD, 5);
 
             // Thiết lập thể chất và linh căn ngẫu nhiên
@@ -150,6 +151,7 @@ public class Player extends GameActor implements DrawableEntity {
             // Tính lại yêu cầu SPIRIT dựa trên hệ số thể chất
             baseSpiritRequirement = 1000;
             spiritToNextLevel = (int) Math.round(baseSpiritRequirement * physique.getSpiritReqFactor());
+            baseAtts.setBase(Attr.SPIRIT, 0);
             baseAtts.setMax(Attr.SPIRIT, spiritToNextLevel);
             baseAtts.set(Attr.SPIRIT, 0);
 
@@ -173,16 +175,35 @@ public class Player extends GameActor implements DrawableEntity {
             addItem(new game.entity.item.elixir.CultivationPill("Đan thượng phẩm", 3, 1));
             addItem(new game.entity.item.elixir.CultivationPill("Đan cực phẩm", 4, 1));
             
-            addItem(new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR));
-            addItem(new EquipmentItem("Mũ sắt", "+3 DEF", "/data/item/equipment/helmet.png", EquipType.HELMET));
-            addItem(new EquipmentItem("Quần vải", "+3 DEF", "/data/item/equipment/pants.png", EquipType.PANTS));
-            addItem(new EquipmentItem("Giày da", "+3 DEF", "/data/item/equipment/shoes.png", EquipType.SHOES));
-            addItem(new EquipmentItem("Kiếm gỗ", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON));
-            addItem(new EquipmentItem("Kiếm sắt", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON));
-            addItem(new EquipmentItem("Dây chuyền", "+10 SOULD", "/data/item/equipment/ring.png", EquipType.NECKLACE));
-            addItem(new EquipmentItem("Nhẫn đá", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING));
-            addItem(new EquipmentItem("Nhẫn bạc", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING));
-            addItem(new EquipmentItem("Bùa hộ mệnh", "Chưa có tác dụng", "/data/item/equipment/d_1.png", EquipType.AMULET));
+            EquipmentItem armor = new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
+            armor.setBonus(Attr.DEF, 3);
+            addItem(armor);
+            EquipmentItem helmet = new EquipmentItem("Mũ sắt", "+3 DEF", "/data/item/equipment/helmet.png", EquipType.HELMET);
+            helmet.setBonus(Attr.DEF, 3);
+            addItem(helmet);
+            EquipmentItem pants = new EquipmentItem("Quần vải", "+3 DEF", "/data/item/equipment/pants.png", EquipType.PANTS);
+            pants.setBonus(Attr.DEF, 3);
+            addItem(pants);
+            EquipmentItem shoes = new EquipmentItem("Giày da", "+3 DEF", "/data/item/equipment/shoes.png", EquipType.SHOES);
+            shoes.setBonus(Attr.DEF, 3);
+            addItem(shoes);
+            EquipmentItem sword1 = new EquipmentItem("Kiếm gỗ", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
+            sword1.setBonus(Attr.ATTACK, 10);
+            addItem(sword1);
+            EquipmentItem sword2 = new EquipmentItem("Kiếm sắt", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
+            sword2.setBonus(Attr.ATTACK, 10);
+            addItem(sword2);
+            EquipmentItem necklace = new EquipmentItem("Dây chuyền", "+10 SOULD", "/data/item/equipment/ring.png", EquipType.NECKLACE);
+            necklace.setBonus(Attr.SOULD, 10);
+            addItem(necklace);
+            EquipmentItem ring1 = new EquipmentItem("Nhẫn đá", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
+            ring1.setBonus(Attr.SOULD, 0);
+            addItem(ring1);
+            EquipmentItem ring2 = new EquipmentItem("Nhẫn bạc", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
+            ring2.setBonus(Attr.SOULD, 0);
+            addItem(ring2);
+            EquipmentItem amulet = new EquipmentItem("Bùa hộ mệnh", "Chưa có tác dụng", "/data/item/equipment/d_1.png", EquipType.AMULET);
+            addItem(amulet);
 
             saveState();
         }
@@ -444,7 +465,7 @@ public class Player extends GameActor implements DrawableEntity {
     // Thêm item vào túi và lưu, trả về true nếu thành công
     public boolean addItem(Item item) {
         boolean added = bag.add(item);
-        saveProfile();
+        PlayerDAO.save(this);
         return added;
     }
 
@@ -711,7 +732,7 @@ public class Player extends GameActor implements DrawableEntity {
 
     public synchronized void saveState() {
         logRealmState();
-        saveProfile();
+        PlayerDAO.save(this);
     }
 
     private void startAutoSave() {
@@ -723,153 +744,6 @@ public class Player extends GameActor implements DrawableEntity {
         saveState();
     }
 
-    /** Persist current player profile to SQL Server. */
-    private void saveProfile() {
-        try (Connection conn = DBAccount.getConnectDB()) {
-            try (Statement st = conn.createStatement()) {
-                st.execute(
-                    "IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'" +
-                    PROFILE_TABLE + "') AND type = N'U') " +
-                    "CREATE TABLE " + PROFILE_TABLE +
-                    " (name NVARCHAR(100) PRIMARY KEY, profile NVARCHAR(MAX))"
-                );
-            }
-
-            List<String> lines = new ArrayList<>();
-            lines.add("CREATION_DATE: " + creationDate.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
-            String items = bag.all().stream()
-                    .map(it -> it.getName() + " (" + it.getQuantity() + ")")
-                    .collect(Collectors.joining(", "));
-            lines.add("Itemcủa nhân vật: " + items);
-
-            lines.add("===EQUIPMENT===");
-            EquipSlot[] order = {
-                EquipSlot.ARMOR,
-                EquipSlot.HELMET,
-                EquipSlot.PANTS,
-                EquipSlot.SHOES,
-                EquipSlot.WEAPON1,
-                EquipSlot.WEAPON2,
-                EquipSlot.NECKLACE,
-                EquipSlot.RING1,
-                EquipSlot.RING2,
-                EquipSlot.AMULET
-            };
-            for (EquipSlot slot : order) {
-                EquipmentItem eq = equipment.get(slot);
-                if (eq != null) {
-                    lines.add("- " + slot.name() + ": " + eq.getId() + "|" + eq.getName() + "|" + eq.getDecription());
-                } else {
-                    lines.add("- " + slot.name() + ": none");
-                }
-            }
-
-            lines.addAll(realmLog);
-            String profileData = String.join("\n", lines);
-
-            String sql = "MERGE " + PROFILE_TABLE + " AS target " +
-                    "USING (SELECT ? AS name, ? AS profile) AS src " +
-                    "ON target.name = src.name " +
-                    "WHEN MATCHED THEN UPDATE SET profile = src.profile " +
-                    "WHEN NOT MATCHED THEN INSERT (name, profile) VALUES (src.name, src.profile);";
-
-            try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                ps.setString(1, getName());
-                ps.setString(2, profileData);
-                ps.executeUpdate();
-            }
-        } catch (ClassNotFoundException | SQLException e) {
-            e.printStackTrace();
-        }
-    }
-
-    /** Load player profile from SQL Server. */
-    private boolean loadProfile() {
-        try (Connection conn = DBAccount.getConnectDB();
-             PreparedStatement ps = conn.prepareStatement(
-                     "SELECT profile FROM " + PROFILE_TABLE + " WHERE name = ?")) {
-            ps.setString(1, getName());
-            try (ResultSet rs = ps.executeQuery()) {
-                if (!rs.next()) return false;
-                String profileData = rs.getString("profile");
-                List<String> lines = Arrays.asList(profileData.split("\\r?\\n"));
-                int idxLine = 0;
-
-                if (idxLine < lines.size() && lines.get(idxLine).startsWith("CREATION_DATE:")) {
-                    String dateStr = lines.get(idxLine).substring("CREATION_DATE:".length()).trim();
-                    creationDate = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
-                    idxLine++;
-                }
-
-                if (idxLine < lines.size()) {
-                    String itemLine = lines.get(idxLine);
-                    String prefix = "Itemcủa nhân vật: ";
-                    if (itemLine.startsWith(prefix)) {
-                        String items = itemLine.substring(prefix.length()).trim();
-                        bag.clear();
-                        if (!items.isEmpty()) {
-                            String[] tokens = items.split(",\\s*");
-                            for (String token : tokens) {
-                                int idxTok = token.lastIndexOf(" (");
-                                int end = token.lastIndexOf(")");
-                                if (idxTok > 0 && end > idxTok) {
-                                    String name = token.substring(0, idxTok).trim();
-                                    int qty = Integer.parseInt(token.substring(idxTok + 2, end));
-                                    Item it = createItemByName(name, qty);
-                                    if (it != null) bag.add(it);
-                                }
-                            }
-                        }
-                    }
-                    idxLine++;
-                }
-
-                if (idxLine < lines.size() && lines.get(idxLine).trim().equals("===EQUIPMENT===")) {
-                    idxLine++;
-                    equipment.clear();
-                    while (idxLine < lines.size()) {
-                        String line = lines.get(idxLine).trim();
-                        if (!line.startsWith("-")) break;
-                        line = line.substring(1).trim();
-                        int colon = line.indexOf(":");
-                        if (colon < 0) { idxLine++; continue; }
-                        String slotName = line.substring(0, colon).trim();
-                        String data = line.substring(colon + 1).trim();
-                        EquipSlot slot;
-                        try {
-                            slot = EquipSlot.valueOf(slotName);
-                        } catch (IllegalArgumentException e) {
-                            idxLine++; continue;
-                        }
-                        if (!data.equalsIgnoreCase("none")) {
-                            String[] partsEq = data.split("\\|");
-                            String id = partsEq.length > 0 ? partsEq[0].trim() : "";
-                            String nameEq = partsEq.length > 1 ? partsEq[1].trim() : "";
-                            String descEq = partsEq.length > 2 ? partsEq[2].trim() : "";
-                            EquipmentItem eq = createEquipmentFromSlot(id, nameEq, descEq, slot);
-                            if (eq != null) {
-                                equipment.put(slot, eq);
-                                if (eq.getType() == EquipType.RING) bag.increaseCapacity(10);
-                            }
-                        }
-                        idxLine++;
-                    }
-                    refreshStats();
-                }
-
-                if (idxLine < lines.size()) {
-                    realmLog.clear();
-                    for (; idxLine < lines.size(); idxLine++) {
-                        realmLog.add(lines.get(idxLine));
-                    }
-                }
-                return true;
-            }
-        } catch (ClassNotFoundException | SQLException e) {
-            e.printStackTrace();
-            return false;
-        }
-    }
     private Physique parsePhysique(String display) {
         for (Physique p : Physique.values()) {
             if (p.getDisplay().equals(display)) return p;
@@ -912,66 +786,6 @@ public class Player extends GameActor implements DrawableEntity {
         return set;
     }
 
-    private Item createItemByName(String name, int qty) {
-        return switch (name) {
-            case "Đan dược hồi máu" -> new game.entity.item.elixir.HealthPotion(50, qty);
-            case "Đan dược tinh thần" -> new game.entity.item.elixir.SpiritPotion(200, qty);
-            case "Đan hạ phẩm" -> new game.entity.item.elixir.CultivationPill("Đan hạ phẩm", 1, qty);
-            case "Đan trung phẩm" -> new game.entity.item.elixir.CultivationPill("Đan trung phẩm", 2, qty);
-            case "Đan thượng phẩm" -> new game.entity.item.elixir.CultivationPill("Đan thượng phẩm", 3, qty);
-            case "Đan cực phẩm" -> new game.entity.item.elixir.CultivationPill("Đan cực phẩm", 4, qty);
-            case "Sách Công pháp hạ phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1));
-            case "Sách Công pháp trung phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 2));
-            case "Sách Công pháp thượng phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 3));
-            
-            case "Sách Công pháp cực phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 5));
-            case "Áo giáp" -> new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
-            case "Mũ sắt" -> new EquipmentItem("Mũ sắt", "+3 DEF", "/data/item/equipment/helmet.png", EquipType.HELMET);
-            case "Quần vải" -> new EquipmentItem("Quần vải", "+3 DEF", "/data/item/equipment/pants.png", EquipType.PANTS);
-            case "Giày da" -> new EquipmentItem("Giày da", "+3 DEF", "/data/item/equipment/shoes.png", EquipType.SHOES);
-            case "Kiếm gỗ" -> new EquipmentItem("Kiếm gỗ", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
-            case "Kiếm sắt" -> new EquipmentItem("Kiếm sắt", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
-            case "Dây chuyền" -> new EquipmentItem("Dây chuyền", "+10 SOULD", "/data/item/equipment/ring.png", EquipType.NECKLACE);
-            case "Nhẫn đá" -> new EquipmentItem("Nhẫn đá", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
-            case "Nhẫn bạc" -> new EquipmentItem("Nhẫn bạc", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
-            case "Bùa hộ mệnh" -> new EquipmentItem("Bùa hộ mệnh", "Chưa có tác dụng", "/data/item/equipment/d_1.png", EquipType.AMULET);
-            
-            default -> null;
-        };
-    }
-
-    private EquipmentItem createEquipmentFromSlot(String id, String name, String desc, EquipSlot slot) {
-        EquipType type = switch (slot) {
-            case ARMOR -> EquipType.ARMOR;
-            case HELMET -> EquipType.HELMET;
-            case PANTS -> EquipType.PANTS;
-            case SHOES -> EquipType.SHOES;
-            case NECKLACE -> EquipType.NECKLACE;
-            case AMULET -> EquipType.AMULET;
-            case RING1, RING2 -> EquipType.RING;
-            case WEAPON1, WEAPON2 -> EquipType.WEAPON;
-        };
-        String icon = switch (slot) {
-            case ARMOR -> "/data/item/equipment/armor.png";
-            case HELMET -> "/data/item/equipment/helmet.png";
-            case PANTS -> "/data/item/equipment/pants.png";
-            case SHOES -> "/data/item/equipment/shoes.png";
-            case NECKLACE -> "/data/item/equipment/ring.png";
-            case AMULET -> "/data/item/equipment/d_1.png";
-            case RING1, RING2 -> "/data/item/equipment/ring.png";
-            case WEAPON1, WEAPON2 -> "/data/item/equipment/sword.png";
-        };
-        if (desc == null || desc.isEmpty()) {
-            desc = switch (type) {
-                case ARMOR, HELMET, PANTS, SHOES -> "+3 DEF";
-                case WEAPON -> "+10 ATTACK";
-                case NECKLACE -> "+10 SOULD";
-                case RING -> "+10 ô kho";
-                case AMULET -> "Chưa có tác dụng";
-            };
-        }
-        return new EquipmentItem(id, name, desc, icon, type);
-    }
 
     // -------- Random Physique/Affinity ---------
 
@@ -1036,23 +850,16 @@ public class Player extends GameActor implements DrawableEntity {
                 .orElse("None");
     }
 
-    private void refreshStats() {
-        atts().setStarts(new EnumMap<>(baseAtts.getStarts()));
-        for (Attr a : Attr.values()) {
-            int max = baseAtts.getMax(a);
-            if (max > 0) {
-                atts().setMax(a, max);
-            } else {
-                atts().setMax(a, Integer.MAX_VALUE);
+    public void refreshStats() {
+        atts().copyFrom(baseAtts);
+        atts().resetBonuses();
+        for (EquipmentItem eq : equipment.values()) {
+            for (var e : eq.getBonuses().entrySet()) {
+                atts().addBonus(e.getKey(), e.getValue());
             }
         }
-        for (EquipmentItem eq : equipment.values()) {
-            switch (eq.getType()) {
-                case HELMET, ARMOR, SHOES, PANTS -> atts().add(Attr.DEF, 3);
-                case WEAPON -> atts().add(Attr.ATTACK, 10);
-                case NECKLACE -> atts().add(Attr.SOULD, 10);
-                default -> {}
-            }
+        for (Attr a : Attr.values()) {
+            atts().set(a, Math.min(atts().get(a), atts().getFinal(a)));
         }
     }
 
@@ -1092,4 +899,10 @@ public class Player extends GameActor implements DrawableEntity {
 
     public static int getInteractionRange() { return INTERACTION_RANGE; }
     public Inventory getBag() { return bag; }
+
+    /** Direct access for DAO classes to base attributes. */
+    public Attributes getBaseAttributes() { return baseAtts; }
+
+    /** Direct access for DAO classes to equipment map. */
+    public EnumMap<EquipSlot, EquipmentItem> getEquipmentMap() { return equipment; }
 }

--- a/src/game/entity/attributes/Attributes.java
+++ b/src/game/entity/attributes/Attributes.java
@@ -6,56 +6,92 @@ import java.util.Map;
 import game.enums.Attr;
 
 /**
- * Lưu trữ các thuộc tính chiến đấu của nhân vật.
- * <p>
- * Mỗi thuộc tính có giá trị hiện tại và giá trị tối đa (để hiển thị thanh máu, năng lượng...).
- * Một số thuộc tính như Attack/Def có thể dùng chung giá trị max hiện tại.
+ * Container for character attributes. Each attribute is represented by a
+ * {@link Stat} storing base, bonus, max and current values.
  */
 public class Attributes {
 
-    /** Giá trị hiện tại của các thuộc tính */
-    private EnumMap<Attr, Integer> stats = new EnumMap<>(Attr.class);
+    /** Map of all attribute stats indexed by {@link Attr}. */
+    private final EnumMap<Attr, Stat> stats = new EnumMap<>(Attr.class);
 
-    /** Giá trị tối đa của các thuộc tính (máu tối đa, pep tối đa, exp cần để lên cấp...) */
-    private EnumMap<Attr, Integer> maxStats = new EnumMap<>(Attr.class);
-
-    /**
-     * Lấy giá trị hiện tại của thuộc tính.
-     */
-    public int get(Attr k) { return stats.getOrDefault(k, 0); }
-
-    /**
-     * Gán giá trị hiện tại của thuộc tính (đã clamp ≥0 và ≤ max nếu có).
-     */
-    public void set(Attr k, int v) {
-        int max = maxStats.getOrDefault(k, Integer.MAX_VALUE);
-        stats.put(k, Math.max(0, Math.min(v, max)));
+    /** Ensure a stat entry exists for the given key. */
+    private Stat stat(Attr k) {
+        return stats.computeIfAbsent(k, a -> new Stat());
     }
 
     /**
-     * Tăng/giảm giá trị thuộc tính, tự động kẹp trong khoảng [0, max].
+     * Get the current value of an attribute.
      */
-    public void add(Attr k, int d) { set(k, get(k) + d); }
+    public int get(Attr k) { return stat(k).getCurrent(); }
 
     /**
-     * Lấy giá trị tối đa của thuộc tính.
+     * Set the current value of an attribute.
      */
-    public int getMax(Attr k) { return maxStats.getOrDefault(k, 0); }
+    public void set(Attr k, int v) { stat(k).setCurrent(v); }
 
     /**
-     * Gán giá trị tối đa của thuộc tính.
+     * Increase/decrease the current value of an attribute.
      */
-    public void setMax(Attr k, int v) {
-        maxStats.put(k, Math.max(0, v));
-        // đảm bảo giá trị hiện tại không vượt quá max mới
-        set(k, get(k));
+    public void add(Attr k, int d) { stat(k).setCurrent(stat(k).getCurrent() + d); }
+
+    /**
+     * Get the maximum cap of an attribute.
+     */
+    public int getMax(Attr k) { return stat(k).getMax(); }
+
+    /**
+     * Set the maximum cap of an attribute.
+     */
+    public void setMax(Attr k, int v) { stat(k).setMax(v); }
+
+    /**
+     * Get base (unmodified) value of an attribute.
+     */
+    public int getBase(Attr k) { return stat(k).getBase(); }
+
+    /**
+     * Set base (unmodified) value of an attribute.
+     */
+    public void setBase(Attr k, int v) { stat(k).setBase(v); }
+
+    /**
+     * Add a bonus modifier to the attribute.
+     */
+    public void addBonus(Attr k, int v) { stat(k).addBonus(v); }
+
+    /**
+     * Get current bonus modifier of the attribute.
+     */
+    public int getBonus(Attr k) { return stat(k).getBonus(); }
+
+    /**
+     * Compute final value (base + bonus) respecting max cap.
+     */
+    public int getFinal(Attr k) { return stat(k).getFinal(); }
+
+    /**
+     * Reset all bonus modifiers to zero.
+     */
+    public void resetBonuses() { stats.values().forEach(Stat::resetBonus); }
+
+    /**
+     * Copy base/max/current values from another {@link Attributes} instance.
+     */
+    public void copyFrom(Attributes other) {
+        for (Attr a : Attr.values()) {
+            Stat src = other.stats.get(a);
+            if (src != null) {
+                Stat dst = stat(a);
+                dst.setBase(src.getBase());
+                dst.setMax(src.getMax());
+                dst.setCurrent(src.getCurrent());
+            }
+        }
     }
 
     /**
-     * Trả về bản sao không thể chỉnh sửa của map thuộc tính hiện tại.
+     * @return unmodifiable view of all stats.
      */
-    public Map<Attr, Integer> view() { return Map.copyOf(stats); }
-
-    public EnumMap<Attr, Integer> getStarts() { return stats; }
-    public Attributes setStarts(EnumMap<Attr, Integer> starts) { this.stats = starts; return this; }
+    public Map<Attr, Stat> view() { return Map.copyOf(stats); }
 }
+

--- a/src/game/entity/attributes/Stat.java
+++ b/src/game/entity/attributes/Stat.java
@@ -1,0 +1,112 @@
+package game.entity.attributes;
+
+/**
+ * Represents a single attribute value with a base amount, bonus modifier and
+ * optional maximum cap. The final value is {@code base + bonus} clamped to
+ * {@code max} if it is greater than zero.
+ */
+public class Stat {
+    private int base;
+    private int bonus;
+    private int max;
+    private int current;
+
+    /**
+     * Set the base (unmodified) value.
+     */
+    public void setBase(int base) {
+        this.base = base;
+        if (current > getFinal()) {
+            current = getFinal();
+        }
+    }
+
+    /**
+     * @return the base (unmodified) value.
+     */
+    public int getBase() {
+        return base;
+    }
+
+    /**
+     * Increase the bonus modifier by {@code d}.
+     */
+    public void addBonus(int d) {
+        this.bonus += d;
+        if (current > getFinal()) {
+            current = getFinal();
+        }
+    }
+
+    /**
+     * Set the bonus modifier directly.
+     */
+    public void setBonus(int bonus) {
+        this.bonus = bonus;
+        if (current > getFinal()) {
+            current = getFinal();
+        }
+    }
+
+    /**
+     * @return current bonus modifier.
+     */
+    public int getBonus() {
+        return bonus;
+    }
+
+    /**
+     * Reset bonus modifier to zero.
+     */
+    public void resetBonus() {
+        this.bonus = 0;
+        if (current > getFinal()) {
+            current = getFinal();
+        }
+    }
+
+    /**
+     * Set maximum cap for this stat. A value ≤ 0 means no cap.
+     */
+    public void setMax(int max) {
+        this.max = Math.max(0, max);
+        if (current > getFinal()) {
+            current = getFinal();
+        }
+    }
+
+    /**
+     * @return the maximum cap (0 if uncapped).
+     */
+    public int getMax() {
+        return max;
+    }
+
+    /**
+     * Set current value (bounded to [0,max] if max>0).
+     */
+    public void setCurrent(int v) {
+        int cap = getFinal();
+        if (max > 0) cap = Math.min(cap, max);
+        this.current = Math.max(0, Math.min(v, cap));
+    }
+
+    /**
+     * @return current value.
+     */
+    public int getCurrent() {
+        return current;
+    }
+
+    /**
+     * @return final value (base + bonus) clamped to max if >0.
+     */
+    public int getFinal() {
+        int total = base + bonus;
+        if (max > 0) {
+            total = Math.min(total, max);
+        }
+        return total;
+    }
+}
+

--- a/src/game/entity/item/EquipmentItem.java
+++ b/src/game/entity/item/EquipmentItem.java
@@ -40,7 +40,7 @@ public class EquipmentItem extends Item {
      * Full constructor including stat bonuses.
      */
     public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type, Map<Attr, Integer> bonusMap) {
-        super(name, desc, 1, 1);
+        super(id, name, desc, 1, 1);
         this.type = type;
         this.iconPath = iconPath;
         this.id = id;

--- a/src/game/entity/item/EquipmentItem.java
+++ b/src/game/entity/item/EquipmentItem.java
@@ -2,10 +2,14 @@ package game.entity.item;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.UUID;
+
 import javax.imageio.ImageIO;
 
 import game.entity.Player;
+import game.enums.Attr;
 import game.enums.EquipType;
 
 /** Basic equipment item that can be equipped in a slot. */
@@ -15,18 +19,27 @@ public class EquipmentItem extends Item {
     private final BufferedImage icon;
     /** Unique identifier for this equipment. */
     private final String id;
+    /** Stat bonuses provided by this equipment. */
+    private final EnumMap<Attr, Integer> bonuses = new EnumMap<>(Attr.class);
 
     /**
      * Create equipment with an auto-generated unique id.
      */
     public EquipmentItem(String name, String desc, String iconPath, EquipType type) {
-        this(type.name() + "#" + UUID.randomUUID().toString(), name, desc, iconPath, type);
+        this(type.name() + "#" + UUID.randomUUID().toString(), name, desc, iconPath, type, Map.of());
     }
 
     /**
      * Create equipment with a specified id.
      */
     public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type) {
+        this(id, name, desc, iconPath, type, Map.of());
+    }
+
+    /**
+     * Full constructor including stat bonuses.
+     */
+    public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type, Map<Attr, Integer> bonusMap) {
         super(name, desc, 1, 1);
         this.type = type;
         this.iconPath = iconPath;
@@ -40,6 +53,7 @@ public class EquipmentItem extends Item {
             }
         }
         this.icon = img;
+        this.bonuses.putAll(bonusMap);
     }
 
     public EquipType getType() {
@@ -54,6 +68,20 @@ public class EquipmentItem extends Item {
         return iconPath;
     }
 
+    /**
+     * @return immutable view of bonuses provided by this equipment.
+     */
+    public Map<Attr, Integer> getBonuses() {
+        return Map.copyOf(bonuses);
+    }
+
+    /**
+     * Add or override a bonus value.
+     */
+    public void setBonus(Attr attr, int value) {
+        bonuses.put(attr, value);
+    }
+
     @Override
     public void use(Player p) {
         var prev = p.equip(this);
@@ -65,8 +93,8 @@ public class EquipmentItem extends Item {
 
     @Override
     public Item copyWithQuantity(int qty) {
-        // Equipment is non-stackable; return identical copy.
-        return new EquipmentItem(getName(), getDecription(), iconPath, type);
+        // Equipment is non-stackable; return identical copy preserving bonuses.
+        return new EquipmentItem(id, getName(), getDecription(), iconPath, type, bonuses);
     }
 
     @Override

--- a/src/game/entity/item/Item.java
+++ b/src/game/entity/item/Item.java
@@ -4,13 +4,19 @@ import java.awt.image.BufferedImage;
 
 import game.entity.Player;
 
+/**
+ * Base class for all items persisted in the database.
+ */
 public abstract class Item {
+    /** Identifier in the {@code Items} table. */
+    private final String id;
     private final String name;
     private final String decription;
     private int quantity;
     private final int maxStack;
 
-    public Item(String name, String decription, int quantity, int maxStack) {
+    public Item(String id, String name, String decription, int quantity, int maxStack) {
+            this.id = id;
             this.name = name;
             this.decription = decription;
             this.quantity = quantity;
@@ -64,4 +70,5 @@ public abstract class Item {
     public int getQuantity() { return quantity; }
     public Item setQuantity(int quantity) { this.quantity = quantity; return this; }
     public int getMaxStack() { return maxStack; }
+    public String getId() { return id; }
 }

--- a/src/game/entity/item/ItemGenerator.java
+++ b/src/game/entity/item/ItemGenerator.java
@@ -1,0 +1,84 @@
+package game.entity.item;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import game.db.DBAccount;
+import game.db.ItemTemplateDAO;
+import game.enums.Attr;
+import game.enums.EquipType;
+
+/**
+ * Utility to create randomized equipment instances from templates.
+ */
+public class ItemGenerator {
+
+    private ItemGenerator() {}
+
+    /**
+     * Generate a new equipment item from the given template id. The created
+     * item is inserted into the {@code Items} and {@code ItemStatMods} tables
+     * with a unique identifier.
+     */
+    public static EquipmentItem createFromTemplate(String templateId)
+            throws SQLException, ClassNotFoundException {
+        ItemTemplate t = ItemTemplateDAO.load(templateId);
+        if (t == null) return null;
+        EnumMap<Attr, Integer> rolled = rollStats(t.getBonuses());
+        String newId = t.getId() + "#" + UUID.randomUUID();
+        persist(newId, t.getName(), t.getType(), rolled);
+        String icon = defaultIcon(t.getType());
+        return new EquipmentItem(newId, t.getName(), "", icon, t.getType(), rolled);
+    }
+
+    private static EnumMap<Attr, Integer> rollStats(Map<Attr, Integer> base) {
+        EnumMap<Attr, Integer> rolled = new EnumMap<>(Attr.class);
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        for (Map.Entry<Attr, Integer> e : base.entrySet()) {
+            int b = e.getValue();
+            int min = (int)(b * 0.8);
+            int max = (int)(b * 1.2);
+            int val = r.nextInt(max - min + 1) + min;
+            rolled.put(e.getKey(), val);
+        }
+        return rolled;
+    }
+
+    private static void persist(String id, String name, EquipType type,
+            Map<Attr, Integer> bonuses) throws SQLException, ClassNotFoundException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            PreparedStatement insItem = conn.prepareStatement(
+                "INSERT INTO Items (ItemId, Name, Type) VALUES (?,?,?)");
+            insItem.setString(1, id);
+            insItem.setString(2, name);
+            insItem.setString(3, type.name());
+            insItem.executeUpdate();
+            PreparedStatement insMod = conn.prepareStatement(
+                "INSERT INTO ItemStatMods (ItemId, Stat, Flat) VALUES (?,?,?)");
+            for (Map.Entry<Attr, Integer> e : bonuses.entrySet()) {
+                insMod.setString(1, id);
+                insMod.setString(2, e.getKey().name());
+                insMod.setInt(3, e.getValue());
+                insMod.addBatch();
+            }
+            insMod.executeBatch();
+        }
+    }
+
+    private static String defaultIcon(EquipType type) {
+        return switch (type) {
+            case ARMOR -> "/data/item/equipment/armor.png";
+            case HELMET -> "/data/item/equipment/helmet.png";
+            case PANTS -> "/data/item/equipment/pants.png";
+            case SHOES -> "/data/item/equipment/shoes.png";
+            case NECKLACE, RING -> "/data/item/equipment/ring.png";
+            case WEAPON -> "/data/item/equipment/sword.png";
+            case AMULET -> "/data/item/equipment/d_1.png";
+        };
+    }
+}

--- a/src/game/entity/item/ItemTemplate.java
+++ b/src/game/entity/item/ItemTemplate.java
@@ -1,0 +1,31 @@
+package game.entity.item;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import game.enums.Attr;
+import game.enums.EquipType;
+
+/**
+ * Immutable definition of an equipment template stored in the database.
+ * Each roll from a template can produce an {@link EquipmentItem} with
+ * randomized bonuses.
+ */
+public class ItemTemplate {
+    private final String id;
+    private final String name;
+    private final EquipType type;
+    private final EnumMap<Attr, Integer> bonuses = new EnumMap<>(Attr.class);
+
+    public ItemTemplate(String id, String name, EquipType type, Map<Attr, Integer> bonusMap) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.bonuses.putAll(bonusMap);
+    }
+
+    public String getId() { return id; }
+    public String getName() { return name; }
+    public EquipType getType() { return type; }
+    public Map<Attr, Integer> getBonuses() { return Map.copyOf(bonuses); }
+}

--- a/src/game/entity/item/MaterialItem.java
+++ b/src/game/entity/item/MaterialItem.java
@@ -12,20 +12,22 @@ public class MaterialItem extends Item {
     private final String iconPath;
     private final BufferedImage icon;
 
-    public MaterialItem(String name, String desc, String iconPath, int quantity, int maxStack) {
-        super(name, desc, quantity, maxStack);
+    public MaterialItem(String id, String name, String desc, String iconPath, int quantity, int maxStack) {
+        super(id, name, desc, quantity, maxStack);
         this.iconPath = iconPath;
-        BufferedImage img;
-        try {
-            img = ImageIO.read(getClass().getResourceAsStream(iconPath));
-        } catch (IOException | IllegalArgumentException e) {
-            img = null;
+        BufferedImage img = null;
+        if (iconPath != null) {
+            try {
+                img = ImageIO.read(getClass().getResourceAsStream(iconPath));
+            } catch (IOException | IllegalArgumentException e) {
+                img = null;
+            }
         }
         this.icon = img;
     }
 
     private MaterialItem(MaterialItem other, int qty) {
-        this(other.getName(), other.getDecription(), other.iconPath, qty, other.getMaxStack());
+        this(other.getId(), other.getName(), other.getDecription(), other.iconPath, qty, other.getMaxStack());
     }
 
     @Override

--- a/src/game/entity/item/book/CultivationBook.java
+++ b/src/game/entity/item/book/CultivationBook.java
@@ -23,8 +23,8 @@ public class CultivationBook extends Item {
         }
     }
 
-    public CultivationBook(CultivationTechnique tech) {
-        super("Sách " + tech.getName(), "Học " + tech.getName(), 1, 1);
+    public CultivationBook(String id, CultivationTechnique tech) {
+        super(id, "Sách " + tech.getName(), "Học " + tech.getName(), 1, 1);
         this.technique = tech;
     }
 
@@ -36,7 +36,7 @@ public class CultivationBook extends Item {
 
     @Override
     public Item copyWithQuantity(int qty) {
-        CultivationBook b = new CultivationBook(technique);
+        CultivationBook b = new CultivationBook(getId(), technique);
         b.setQuantity(qty);
         return b;
     }

--- a/src/game/entity/item/elixir/CultivationPill.java
+++ b/src/game/entity/item/elixir/CultivationPill.java
@@ -23,8 +23,8 @@ public class CultivationPill extends Item {
         }
     }
 
-    public CultivationPill(String name, int spiritBonus, int quantity) {
-        super(name, "Tăng tốc độ tu luyện", quantity, 100);
+    public CultivationPill(String id, String name, int spiritBonus, int quantity) {
+        super(id, name, "Tăng tốc độ tu luyện", quantity, 100);
         this.spiritBonus = spiritBonus;
     }
 
@@ -35,9 +35,9 @@ public class CultivationPill extends Item {
     }
 
     @Override
-    public Item copyWithQuantity(int qty) {
-        return new CultivationPill(getName(), spiritBonus, qty);
-    }
+      public Item copyWithQuantity(int qty) {
+          return new CultivationPill(getId(), getName(), spiritBonus, qty);
+      }
 
     @Override
     public boolean isSameStack(Item other) {

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -21,14 +21,14 @@ public class HealthPotion extends Item {
 		}
 	}
 	
-	public HealthPotion(int healthAmount, int quantity) {
-		super(
-				"Đan dược hồi máu", 
-				"Dùng để hồi máu", 
-				quantity,
-				100);
-		this.healthAmount = healthAmount;
-	}
+    public HealthPotion(String id, int healthAmount, int quantity) {
+            super(id,
+                            "Đan dược hồi máu",
+                            "Dùng để hồi máu",
+                            quantity,
+                            100);
+            this.healthAmount = healthAmount;
+    }
 
 	@Override
     public void use(Player p) {
@@ -40,9 +40,9 @@ public class HealthPotion extends Item {
 }
 	
    @Override
-    public Item copyWithQuantity(int qty) {
-        return new HealthPotion(healthAmount, qty);
-    }
+      public Item copyWithQuantity(int qty) {
+          return new HealthPotion(getId(), healthAmount, qty);
+      }
 	
    @Override
     public boolean isSameStack(Item other) {

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -25,8 +25,8 @@ public class SpiritPotion extends Item {
         }
     }
 
-    public SpiritPotion(int spiritAmount, int quantity) {
-        super("Đan dược tinh thần", "Tăng " + spiritAmount + " Spirit", quantity, 100);
+    public SpiritPotion(String id, int spiritAmount, int quantity) {
+        super(id, "Đan dược tinh thần", "Tăng " + spiritAmount + " Spirit", quantity, 100);
         this.spiritAmount = spiritAmount;
     }
 
@@ -38,9 +38,9 @@ public class SpiritPotion extends Item {
     }
 
     @Override
-    public Item copyWithQuantity(int qty) {
-        return new SpiritPotion(spiritAmount, qty);
-    }
+      public Item copyWithQuantity(int qty) {
+          return new SpiritPotion(getId(), spiritAmount, qty);
+      }
 
     @Override
     public boolean isSameStack(Item other) {

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -327,7 +327,7 @@ public abstract class Monster extends GameActor {
      */
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
-        list.add(new game.entity.item.elixir.HealthPotion(30, 1));
+        list.add(new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1));
         return list;
     }
 

--- a/src/game/entity/monster/Orc.java
+++ b/src/game/entity/monster/Orc.java
@@ -73,8 +73,8 @@ public class Orc extends Monster {
     @Override
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
-        list.add(new game.entity.item.MaterialItem("Xương Orc", "Bone", "/data/item/orc/ORC_Bone.png", 1, 20));
-        list.add(new game.entity.item.MaterialItem("Thịt Orc", "Flesh", "/data/item/orc/ORC_Flesh.png", 1, 20));
+        list.add(new game.entity.item.MaterialItem("ORC_BONE", "Xương Orc", "Bone", "/data/item/orc/ORC_Bone.png", 1, 20));
+        list.add(new game.entity.item.MaterialItem("ORC_FLESH", "Thịt Orc", "Flesh", "/data/item/orc/ORC_Flesh.png", 1, 20));
         return list;
     }
 

--- a/src/game/entity/monster/SkeletonLord.java
+++ b/src/game/entity/monster/SkeletonLord.java
@@ -73,7 +73,7 @@ public class SkeletonLord extends Monster {
     @Override
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
-        list.add(new game.entity.item.MaterialItem("Xương Skeleton", "Bone", "/data/item/skeleton/SKELETON_Bone.png", 1, 20));
+        list.add(new game.entity.item.MaterialItem("SKEL_BONE", "Xương Skeleton", "Bone", "/data/item/skeleton/SKELETON_Bone.png", 1, 20));
         return list;
     }
 

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,3 @@
+1. Chạy `ItemGenerator.createFromTemplate("TEMPLATE_ID")` và kiểm tra hàng mới trong bảng `Items` và `ItemStatMods`.
+2. Tạo nhân vật, nhặt vật phẩm tiêu hao và lưu game để kiểm tra `PlayerInventory` lưu mọi item.
+3. Đọc `ItemAndStatGuide.md` để thêm trang bị mới, sau đó dùng ItemDAO.load xác nhận xuất hiện.


### PR DESCRIPTION
## Summary
- replace PlayerProfile serialization with DAO layer storing data across Players, PlayerBaseStats, PlayerRuntime, PlayerInventory and PlayerEquipment tables
- load item definitions and stat modifiers via new ItemDAO and apply bonuses on EquipmentItem
- refactor Attributes with base/bonus Stat model and update Player.refreshStats

## Testing
- `javac $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68aeb81a92e0832f908ce080bd5958b2