### PR TITLE
Refactor attributes with base and bonus support

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,0 +1,1 @@
+Compile toàn bộ mã nguồn với javac để đảm bảo không lỗi biên dịch.

--- a/Change.txt
+++ b/Change.txt
@@ -95,3 +95,9 @@ Sửa lỗi và cải tiến:
 - Đổi tên cột `Percent` thành `PercentBonus` trong `sql/game_db_core_schema.sql` để tránh từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa có.
 - Cập nhật README hướng dẫn chạy script trước khi khởi động game.
+
+## 1.0.23
+- Thêm lớp `Stat` và tái cấu trúc `Attributes` để tách **giá trị gốc** và **bonus**.
+- `EquipmentItem` chứa `EnumMap<Attr,Integer>` mô tả chỉ số cộng thêm.
+- `Player.refreshStats()` cộng dồn bonus từ trang bị vào thuộc tính cuối cùng.
+- Cập nhật tạo trang bị mẫu với bonus tương ứng.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 - Đổi tên cột `ItemStatMods.Percent` thành `PercentBonus` để tránh xung đột từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa tồn tại.
 
+## [1.0.23]
+
+### Thêm
+- `Attributes` dùng lớp `Stat` để quản lý base/bonus/max của từng chỉ số.
+- `EquipmentItem` mang theo các bonus stat và `Player.refreshStats()` cộng dồn tự động.
+
 ## [1.0.20]
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -11,9 +11,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -134,14 +135,14 @@ public class Player extends GameActor implements DrawableEntity {
         if (!loadProfile()) {
             // Thuộc tính cơ bản
             baseAtts.setMax(Attr.HEALTH, 100);
-            baseAtts.set(Attr.HEALTH, 100);
+            baseAtts.setBase(Attr.HEALTH, 100);
             baseAtts.setMax(Attr.PEP, 100);
-            baseAtts.set(Attr.PEP, 100);
+            baseAtts.setBase(Attr.PEP, 100);
             // Attack/Def không còn giới hạn max mặc định để có thể tăng khi lên cấp
-            baseAtts.set(Attr.ATTACK, 5);
-            baseAtts.set(Attr.DEF, 4);
-            baseAtts.set(Attr.STRENGTH, 1);
-            baseAtts.set(Attr.SOULD, 5);
+            baseAtts.setBase(Attr.ATTACK, 5);
+            baseAtts.setBase(Attr.DEF, 4);
+            baseAtts.setBase(Attr.STRENGTH, 1);
+            baseAtts.setBase(Attr.SOULD, 5);
 
             // Thiết lập thể chất và linh căn ngẫu nhiên
             physique = randomPhysique();
@@ -151,7 +152,7 @@ public class Player extends GameActor implements DrawableEntity {
             baseSpiritRequirement = 1000;
             spiritToNextLevel = (int) Math.round(baseSpiritRequirement * physique.getSpiritReqFactor());
             baseAtts.setMax(Attr.SPIRIT, spiritToNextLevel);
-            baseAtts.set(Attr.SPIRIT, 0);
+            baseAtts.setBase(Attr.SPIRIT, 0);
 
             // Thêm vài item test: bình hồi máu & tinh thần
             addItem(new game.entity.item.elixir.HealthPotion(50, 3));
@@ -333,7 +334,7 @@ public class Player extends GameActor implements DrawableEntity {
                         }
                     } else if (monster instanceof GameActor m) {
                         // Quái vật cũ chỉ trừ máu đơn giản
-                        m.atts().add(Attr.HEALTH, -damage);
+                        m.atts().addBase(Attr.HEALTH, -damage);
                         if (m.atts().get(Attr.HEALTH) <= 0) {
                             gp.getMonsters().remove(i);
                             i--;
@@ -354,8 +355,8 @@ public class Player extends GameActor implements DrawableEntity {
 
         int monsterIndex = gp.getCheckCollision().checkEntity(this, gp.getMonsters());
         if (monsterIndex != 999 && !invincible) {
-            atts().add(Attr.HEALTH, -1);
-            baseAtts.add(Attr.HEALTH, -1);
+            atts().addBase(Attr.HEALTH, -1);
+            baseAtts.addBase(Attr.HEALTH, -1);
             gp.getUi().triggerDamageEffect();
             invincible = true;
         }
@@ -461,9 +462,9 @@ public class Player extends GameActor implements DrawableEntity {
     public void gainSpirit(int amount) {
         // Tiên Linh Thể tu luyện nhanh gấp 3 lần
         int modified = (int) Math.round(amount * physique.getCultivationSpeedFactor());
-        baseAtts.add(Attr.SPIRIT, modified);
+        baseAtts.addBase(Attr.SPIRIT, modified);
         while (baseAtts.get(Attr.SPIRIT) >= spiritToNextLevel) {
-            baseAtts.add(Attr.SPIRIT, -spiritToNextLevel);
+            baseAtts.addBase(Attr.SPIRIT, -spiritToNextLevel);
             levelUp();
         }
         refreshStats();
@@ -563,13 +564,13 @@ public class Player extends GameActor implements DrawableEntity {
                 initializeLuyenThe();
                 baseSpiritRequirement += baseSpiritRequirement / 2;
                 spiritToNextLevel = (int) Math.round(baseSpiritRequirement * physique.getSpiritReqFactor());
-                baseAtts.add(Attr.SOULD, 10);
+                baseAtts.addBase(Attr.SOULD, 10);
             }
             case LUYEN_THE -> {
                 realmStage++;
                 if (realmStage > physique.getMaxStage()) {
                     breakThroughToLuyenKhi();
-                    baseAtts.add(Attr.SOULD, 10);
+                    baseAtts.addBase(Attr.SOULD, 10);
                 } else {
                     applyStageGrowth();
                     baseSpiritRequirement += baseSpiritRequirement / 2;
@@ -599,15 +600,15 @@ public class Player extends GameActor implements DrawableEntity {
     private void initializeLuyenThe() {
         int hp = (int) (150 * physique.getStatFactor());
         baseAtts.setMax(Attr.HEALTH, hp);
-        baseAtts.set(Attr.HEALTH, hp);
+        baseAtts.setBase(Attr.HEALTH, hp);
 
         int pep = (int) (150 * physique.getStatFactor());
         baseAtts.setMax(Attr.PEP, pep);
-        baseAtts.set(Attr.PEP, pep);
+        baseAtts.setBase(Attr.PEP, pep);
 
-        baseAtts.set(Attr.ATTACK, (int) (10 * physique.getStatFactor()));
-        baseAtts.set(Attr.DEF, (int) (5 * physique.getDefFactor()));
-        baseAtts.set(Attr.STRENGTH, (int) (2 * physique.getStatFactor()));
+        baseAtts.setBase(Attr.ATTACK, (int) (10 * physique.getStatFactor()));
+        baseAtts.setBase(Attr.DEF, (int) (5 * physique.getDefFactor()));
+        baseAtts.setBase(Attr.STRENGTH, (int) (2 * physique.getStatFactor()));
     }
 
     /**
@@ -621,27 +622,27 @@ public class Player extends GameActor implements DrawableEntity {
         int hpInc = (int) (stage * 50 * physique.getStatFactor());
         int newHp = baseAtts.getMax(Attr.HEALTH) + hpInc;
         baseAtts.setMax(Attr.HEALTH, newHp);
-        baseAtts.set(Attr.HEALTH, newHp);
+        baseAtts.setBase(Attr.HEALTH, newHp);
 
         int pepInc = (int) (stage * 50 * physique.getStatFactor());
         int newPep = baseAtts.getMax(Attr.PEP) + pepInc;
         baseAtts.setMax(Attr.PEP, newPep);
-        baseAtts.set(Attr.PEP, newPep);
+        baseAtts.setBase(Attr.PEP, newPep);
 
         // ATTACK: +1, riêng bội số của 3 cộng thêm chính số đó
         int atkInc = (stage % 3 == 0) ? stage : 1;
-        baseAtts.add(Attr.ATTACK, (int) (atkInc * physique.getStatFactor()));
+        baseAtts.addBase(Attr.ATTACK, (int) (atkInc * physique.getStatFactor()));
 
         // DEF: +1, bội số của 3 cộng thêm stage/2 (làm tròn lên)
         int defInc = 1;
         if (stage % 3 == 0) {
             defInc = (stage + 1) / 2;
         }
-        baseAtts.add(Attr.DEF, (int) (defInc * physique.getDefFactor()));
+        baseAtts.addBase(Attr.DEF, (int) (defInc * physique.getDefFactor()));
 
         // STRENGTH: +1 ở bội số của 3
         if (stage % 3 == 0) {
-            baseAtts.add(Attr.STRENGTH, (int) (1 * physique.getStatFactor()));
+            baseAtts.addBase(Attr.STRENGTH, (int) (1 * physique.getStatFactor()));
         }
     }
 
@@ -654,23 +655,23 @@ public class Player extends GameActor implements DrawableEntity {
 
         int hp = (int) (baseAtts.getMax(Attr.HEALTH) * 2 * physique.getStatFactor());
         baseAtts.setMax(Attr.HEALTH, hp);
-        baseAtts.set(Attr.HEALTH, hp);
+        baseAtts.setBase(Attr.HEALTH, hp);
 
         int pep = (int) (baseAtts.getMax(Attr.PEP) * 2 * physique.getStatFactor());
         baseAtts.setMax(Attr.PEP, pep);
-        baseAtts.set(Attr.PEP, pep);
+        baseAtts.setBase(Attr.PEP, pep);
 
         int atk = (int) (baseAtts.get(Attr.ATTACK) * 2 * physique.getStatFactor());
-        baseAtts.set(Attr.ATTACK, atk);
+        baseAtts.setBase(Attr.ATTACK, atk);
 
         int def = (int) (baseAtts.get(Attr.DEF) * 3 * physique.getDefFactor());
-        baseAtts.set(Attr.DEF, def);
+        baseAtts.setBase(Attr.DEF, def);
 
         int str = (int) (baseAtts.get(Attr.STRENGTH) * 2 * physique.getStatFactor());
-        baseAtts.set(Attr.STRENGTH, str);
+        baseAtts.setBase(Attr.STRENGTH, str);
 
         int soul = (int) (baseAtts.get(Attr.SOULD) * 2 * physique.getStatFactor());
-        baseAtts.set(Attr.SOULD, soul);
+        baseAtts.setBase(Attr.SOULD, soul);
 
         baseSpiritRequirement *= 2;
         spiritToNextLevel = (int) Math.round(baseSpiritRequirement * physique.getSpiritReqFactor());
@@ -925,13 +926,13 @@ public class Player extends GameActor implements DrawableEntity {
             case "Sách Công pháp thượng phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 3));
             
             case "Sách Công pháp cực phẩm" -> new game.entity.item.book.CultivationBook(new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 5));
-            case "Áo giáp" -> new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
-            case "Mũ sắt" -> new EquipmentItem("Mũ sắt", "+3 DEF", "/data/item/equipment/helmet.png", EquipType.HELMET);
-            case "Quần vải" -> new EquipmentItem("Quần vải", "+3 DEF", "/data/item/equipment/pants.png", EquipType.PANTS);
-            case "Giày da" -> new EquipmentItem("Giày da", "+3 DEF", "/data/item/equipment/shoes.png", EquipType.SHOES);
-            case "Kiếm gỗ" -> new EquipmentItem("Kiếm gỗ", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
-            case "Kiếm sắt" -> new EquipmentItem("Kiếm sắt", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
-            case "Dây chuyền" -> new EquipmentItem("Dây chuyền", "+10 SOULD", "/data/item/equipment/ring.png", EquipType.NECKLACE);
+            case "Áo giáp" -> new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR, Map.of(Attr.DEF,3));
+            case "Mũ sắt" -> new EquipmentItem("Mũ sắt", "+3 DEF", "/data/item/equipment/helmet.png", EquipType.HELMET, Map.of(Attr.DEF,3));
+            case "Quần vải" -> new EquipmentItem("Quần vải", "+3 DEF", "/data/item/equipment/pants.png", EquipType.PANTS, Map.of(Attr.DEF,3));
+            case "Giày da" -> new EquipmentItem("Giày da", "+3 DEF", "/data/item/equipment/shoes.png", EquipType.SHOES, Map.of(Attr.DEF,3));
+            case "Kiếm gỗ" -> new EquipmentItem("Kiếm gỗ", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON, Map.of(Attr.ATTACK,10));
+            case "Kiếm sắt" -> new EquipmentItem("Kiếm sắt", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON, Map.of(Attr.ATTACK,10));
+            case "Dây chuyền" -> new EquipmentItem("Dây chuyền", "+10 SOULD", "/data/item/equipment/ring.png", EquipType.NECKLACE, Map.of(Attr.SOULD,10));
             case "Nhẫn đá" -> new EquipmentItem("Nhẫn đá", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
             case "Nhẫn bạc" -> new EquipmentItem("Nhẫn bạc", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
             case "Bùa hộ mệnh" -> new EquipmentItem("Bùa hộ mệnh", "Chưa có tác dụng", "/data/item/equipment/d_1.png", EquipType.AMULET);
@@ -970,7 +971,13 @@ public class Player extends GameActor implements DrawableEntity {
                 case AMULET -> "Chưa có tác dụng";
             };
         }
-        return new EquipmentItem(id, name, desc, icon, type);
+        Map<Attr,Integer> bonus = switch (type) {
+            case ARMOR, HELMET, PANTS, SHOES -> Map.of(Attr.DEF,3);
+            case WEAPON -> Map.of(Attr.ATTACK,10);
+            case NECKLACE -> Map.of(Attr.SOULD,10);
+            default -> Map.of();
+        };
+        return new EquipmentItem(id, name, desc, icon, type, bonus);
     }
 
     // -------- Random Physique/Affinity ---------
@@ -1037,21 +1044,13 @@ public class Player extends GameActor implements DrawableEntity {
     }
 
     private void refreshStats() {
-        atts().setStarts(new EnumMap<>(baseAtts.getStarts()));
+        atts().copyBaseFrom(baseAtts);
         for (Attr a : Attr.values()) {
-            int max = baseAtts.getMax(a);
-            if (max > 0) {
-                atts().setMax(a, max);
-            } else {
-                atts().setMax(a, Integer.MAX_VALUE);
-            }
+            atts().setBonus(a, 0);
         }
         for (EquipmentItem eq : equipment.values()) {
-            switch (eq.getType()) {
-                case HELMET, ARMOR, SHOES, PANTS -> atts().add(Attr.DEF, 3);
-                case WEAPON -> atts().add(Attr.ATTACK, 10);
-                case NECKLACE -> atts().add(Attr.SOULD, 10);
-                default -> {}
+            for (var e : eq.getBonuses().entrySet()) {
+                atts().addBonus(e.getKey(), e.getValue());
             }
         }
     }

--- a/src/game/entity/attributes/Attributes.java
+++ b/src/game/entity/attributes/Attributes.java
@@ -6,56 +6,63 @@ import java.util.Map;
 import game.enums.Attr;
 
 /**
- * Lưu trữ các thuộc tính chiến đấu của nhân vật.
- * <p>
- * Mỗi thuộc tính có giá trị hiện tại và giá trị tối đa (để hiển thị thanh máu, năng lượng...).
- * Một số thuộc tính như Attack/Def có thể dùng chung giá trị max hiện tại.
+ * Stores a collection of Stats for an actor. Each attribute consists of
+ * base, bonus and optional max values. Final value is base + bonus clamped to
+ * max.
  */
 public class Attributes {
 
-    /** Giá trị hiện tại của các thuộc tính */
-    private EnumMap<Attr, Integer> stats = new EnumMap<>(Attr.class);
+    private EnumMap<Attr, Stat> stats = new EnumMap<>(Attr.class);
 
-    /** Giá trị tối đa của các thuộc tính (máu tối đa, pep tối đa, exp cần để lên cấp...) */
-    private EnumMap<Attr, Integer> maxStats = new EnumMap<>(Attr.class);
-
-    /**
-     * Lấy giá trị hiện tại của thuộc tính.
-     */
-    public int get(Attr k) { return stats.getOrDefault(k, 0); }
-
-    /**
-     * Gán giá trị hiện tại của thuộc tính (đã clamp ≥0 và ≤ max nếu có).
-     */
-    public void set(Attr k, int v) {
-        int max = maxStats.getOrDefault(k, Integer.MAX_VALUE);
-        stats.put(k, Math.max(0, Math.min(v, max)));
+    public Attributes() {
+        for (Attr a : Attr.values()) {
+            stats.put(a, new Stat());
+        }
     }
 
-    /**
-     * Tăng/giảm giá trị thuộc tính, tự động kẹp trong khoảng [0, max].
-     */
-    public void add(Attr k, int d) { set(k, get(k) + d); }
+    /** Return final value of the attribute. */
+    public int get(Attr k) { return stats.get(k).getFinal(); }
 
-    /**
-     * Lấy giá trị tối đa của thuộc tính.
-     */
-    public int getMax(Attr k) { return maxStats.getOrDefault(k, 0); }
+    /** Return base value. */
+    public int getBase(Attr k) { return stats.get(k).getBase(); }
 
-    /**
-     * Gán giá trị tối đa của thuộc tính.
-     */
-    public void setMax(Attr k, int v) {
-        maxStats.put(k, Math.max(0, v));
-        // đảm bảo giá trị hiện tại không vượt quá max mới
-        set(k, get(k));
+    /** Set base value. */
+    public void setBase(Attr k, int v) { stats.get(k).setBase(v); }
+
+    /** Increase base by delta. */
+    public void addBase(Attr k, int d) { stats.get(k).addBase(d); }
+
+    /** Add bonus value (can be negative). */
+    public void addBonus(Attr k, int d) { stats.get(k).addBonus(d); }
+
+    /** Reset bonus for the attribute. */
+    public void setBonus(Attr k, int v) { stats.get(k).setBonus(v); }
+
+    /** Get bonus of attribute. */
+    public int getBonus(Attr k) { return stats.get(k).getBonus(); }
+
+    /** Get max value. */
+    public int getMax(Attr k) { return stats.get(k).getMax(); }
+
+    /** Set max value. */
+    public void setMax(Attr k, int v) { stats.get(k).setMax(v); }
+
+    /** View immutable copy of base values. */
+    public Map<Attr, Integer> viewBase() {
+        EnumMap<Attr, Integer> map = new EnumMap<>(Attr.class);
+        for (var e : stats.entrySet()) {
+            map.put(e.getKey(), e.getValue().getBase());
+        }
+        return Map.copyOf(map);
     }
 
-    /**
-     * Trả về bản sao không thể chỉnh sửa của map thuộc tính hiện tại.
-     */
-    public Map<Attr, Integer> view() { return Map.copyOf(stats); }
-
-    public EnumMap<Attr, Integer> getStarts() { return stats; }
-    public Attributes setStarts(EnumMap<Attr, Integer> starts) { this.stats = starts; return this; }
+    /** Copy base and max values from another Attributes. */
+    public void copyBaseFrom(Attributes other) {
+        for (Attr a : Attr.values()) {
+            Stat src = other.stats.get(a);
+            Stat dst = this.stats.get(a);
+            dst.setBase(src.getBase());
+            dst.setMax(src.getMax());
+        }
+    }
 }

--- a/src/game/entity/attributes/Stat.java
+++ b/src/game/entity/attributes/Stat.java
@@ -1,0 +1,59 @@
+package game.entity.attributes;
+
+/**
+ * Represents a single numeric attribute with base, bonus and maximum values.
+ */
+public class Stat {
+    private int base;
+    private int bonus;
+    private int max;
+
+    public Stat() {
+        this(0,0,0);
+    }
+
+    public Stat(int base, int bonus, int max) {
+        this.base = base;
+        this.bonus = bonus;
+        this.max = max;
+    }
+
+    /** @return base value without any bonuses. */
+    public int getBase() { return base; }
+
+    /** Set base value. Clamped to not exceed max if max>0. */
+    public void setBase(int v) {
+        base = v;
+        if (max > 0 && base > max) base = max;
+        if (base < 0) base = 0;
+    }
+
+    /** Increase base value by delta. */
+    public void addBase(int d) { setBase(base + d); }
+
+    /** @return bonus value applied on top of base. */
+    public int getBonus() { return bonus; }
+
+    /** Set bonus value. */
+    public void setBonus(int v) { bonus = v; }
+
+    /** Increase bonus by delta. */
+    public void addBonus(int d) { bonus += d; }
+
+    /** @return maximum allowed value (applied after bonus). */
+    public int getMax() { return max; }
+
+    /** Set maximum allowed value. */
+    public void setMax(int v) {
+        max = v;
+        if (max > 0 && base > max) base = max;
+    }
+
+    /** Compute final value = min(base + bonus, max) if max>0. */
+    public int getFinal() {
+        int val = base + bonus;
+        if (max > 0 && val > max) val = max;
+        if (val < 0) val = 0;
+        return val;
+    }
+}

--- a/src/game/entity/item/EquipmentItem.java
+++ b/src/game/entity/item/EquipmentItem.java
@@ -2,10 +2,13 @@ package game.entity.item;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.UUID;
 import javax.imageio.ImageIO;
 
 import game.entity.Player;
+import game.enums.Attr;
 import game.enums.EquipType;
 
 /** Basic equipment item that can be equipped in a slot. */
@@ -15,18 +18,34 @@ public class EquipmentItem extends Item {
     private final BufferedImage icon;
     /** Unique identifier for this equipment. */
     private final String id;
+    /** Stat bonuses provided by this equipment. */
+    private final EnumMap<Attr, Integer> bonuses = new EnumMap<>(Attr.class);
 
     /**
      * Create equipment with an auto-generated unique id.
      */
     public EquipmentItem(String name, String desc, String iconPath, EquipType type) {
-        this(type.name() + "#" + UUID.randomUUID().toString(), name, desc, iconPath, type);
+        this(type.name() + "#" + UUID.randomUUID().toString(), name, desc, iconPath, type, Map.of());
+    }
+
+    /**
+     * Create equipment with auto-generated id and bonuses.
+     */
+    public EquipmentItem(String name, String desc, String iconPath, EquipType type, Map<Attr,Integer> bonusMap) {
+        this(type.name() + "#" + UUID.randomUUID().toString(), name, desc, iconPath, type, bonusMap);
     }
 
     /**
      * Create equipment with a specified id.
      */
     public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type) {
+        this(id, name, desc, iconPath, type, Map.of());
+    }
+
+    /**
+     * Full constructor specifying bonuses.
+     */
+    public EquipmentItem(String id, String name, String desc, String iconPath, EquipType type, Map<Attr,Integer> bonusMap) {
         super(name, desc, 1, 1);
         this.type = type;
         this.iconPath = iconPath;
@@ -40,6 +59,7 @@ public class EquipmentItem extends Item {
             }
         }
         this.icon = img;
+        this.bonuses.putAll(bonusMap);
     }
 
     public EquipType getType() {
@@ -54,6 +74,9 @@ public class EquipmentItem extends Item {
         return iconPath;
     }
 
+    /** @return immutable view of stat bonuses. */
+    public Map<Attr,Integer> getBonuses() { return Map.copyOf(bonuses); }
+
     @Override
     public void use(Player p) {
         var prev = p.equip(this);
@@ -66,7 +89,7 @@ public class EquipmentItem extends Item {
     @Override
     public Item copyWithQuantity(int qty) {
         // Equipment is non-stackable; return identical copy.
-        return new EquipmentItem(getName(), getDecription(), iconPath, type);
+        return new EquipmentItem(getId(), getName(), getDecription(), iconPath, type, bonuses);
     }
 
     @Override

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -35,7 +35,7 @@ public class HealthPotion extends Item {
         int current = p.atts().get(Attr.HEALTH);
         int max = p.atts().getMax(Attr.HEALTH);
         int newHealth = Math.min(current + healthAmount, max);
-        p.atts().set(Attr.HEALTH, newHealth);
+        p.atts().setBase(Attr.HEALTH, newHealth);
         decreaseQuantity(1);
 }
 	

--- a/src/game/entity/monster/GreenSlime.java
+++ b/src/game/entity/monster/GreenSlime.java
@@ -34,7 +34,7 @@ public class GreenSlime extends GameActor {
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
         setCollisionArea(new Rectangle(8, 16, 32, 32));
-        atts().set(Attr.HEALTH, 10);
+        atts().setBase(Attr.HEALTH, 10);
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());
     }
 
@@ -114,7 +114,7 @@ public class GreenSlime extends GameActor {
                 gp.getPlayer().getCollisionArea().height
         );
         if (attackRect.intersects(playerRect)) {
-            gp.getPlayer().atts().add(Attr.HEALTH, -attackDamage);
+            gp.getPlayer().atts().addBase(Attr.HEALTH, -attackDamage);
             gp.getUi().triggerDamageEffect();
         }
     }

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -249,7 +249,7 @@ public abstract class Monster extends GameActor {
             gp.getPlayer().getCollisionArea().height
         );
         if (attackRect.intersects(playerRect)) {
-            gp.getPlayer().atts().add(Attr.HEALTH, -attackDamage);
+            gp.getPlayer().atts().addBase(Attr.HEALTH, -attackDamage);
             gp.getUi().triggerDamageEffect();
         }
         if (canAttackMonsters) {
@@ -270,7 +270,7 @@ public abstract class Monster extends GameActor {
                             i--;
                         }
                     } else if (other instanceof GameActor m) {
-                        m.atts().add(Attr.HEALTH, -attackDamage);
+                        m.atts().addBase(Attr.HEALTH, -attackDamage);
                         if (m.atts().get(Attr.HEALTH) <= 0) {
                             gp.getMonsters().remove(i);
                             i--;
@@ -306,7 +306,7 @@ public abstract class Monster extends GameActor {
      * @return true nếu quái vật chết
      */
     public boolean takeDamage(int amount) {
-        atts().add(Attr.HEALTH, -amount);
+        atts().addBase(Attr.HEALTH, -amount);
         healthBarCounter = HEALTH_BAR_TIME;
         return atts().get(Attr.HEALTH) <= 0;
     }

--- a/src/game/entity/monster/Orc.java
+++ b/src/game/entity/monster/Orc.java
@@ -42,7 +42,7 @@ public class Orc extends Monster {
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
         setCollisionArea(new Rectangle(8, 16, 32, 32));
-        atts().set(Attr.HEALTH, 20);
+        atts().setBase(Attr.HEALTH, 20);
         maxHealth = 20;
         attackDamage = 4;
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());

--- a/src/game/entity/monster/SkeletonLord.java
+++ b/src/game/entity/monster/SkeletonLord.java
@@ -42,7 +42,7 @@ public class SkeletonLord extends Monster {
         setScaleEntityX(gp.getTileSize());
         setScaleEntityY(gp.getTileSize());
         setCollisionArea(new Rectangle(8, 16, 32, 32));
-        atts().set(Attr.HEALTH, 30);
+        atts().setBase(Attr.HEALTH, 30);
         maxHealth = 30;
         attackDamage = 5;
         attackArea = new Rectangle(0, 0, gp.getTileSize(), gp.getTileSize());

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,3 @@
+1. Chạy game và trang bị thử "Áo giáp" rồi mở bảng thuộc tính để kiểm tra DEF tăng 3.
+2. Trang bị "Kiếm gỗ" để kiểm tra ATTACK tăng 10.
+3. Dùng bình máu và chắc chắn HEALTH không vượt quá giới hạn tối đa.


### PR DESCRIPTION
## Summary
- introduce `Stat` class and refactor `Attributes` to track base and bonus values
- allow `EquipmentItem` to carry stat bonuses and apply them in `Player.refreshStats`
- adjust consumables and monsters to new attribute API

## Testing
- `javac -d bin @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68aeb8a98ea4832f87aa2058a5519b5d