### PR TITLE
Persist consumable and material items

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,1 +1,1 @@
-Compiled all Java source files with `javac $(find src -name "*.java")` to ensure build succeeds.
+Đã biên dịch toàn bộ mã nguồn bằng `javac $(find src -name "*.java")` để đảm bảo không lỗi cú pháp sau khi thêm ItemDAO.insert và cập nhật PlayerDAO.saveInventory.

--- a/Change.txt
+++ b/Change.txt
@@ -106,3 +106,8 @@ Sửa lỗi và cải tiến:
 ## 1.0.24
 - Mỗi `Item` mang mã `id`, kho đồ lưu được cả tiêu hao và vật liệu.
 - Thêm `ItemTemplateDAO` và `ItemGenerator` tạo trang bị ngẫu nhiên từ mẫu.
+
+## 1.0.25
+- Thêm `ItemDAO.insert` để ghi vật phẩm tiêu hao và vật liệu mới vào `Items`/`ItemStatMods`.
+- `PlayerDAO.saveInventory` tự bỏ qua hoặc chèn những item chưa có bản ghi cơ sở dữ liệu.
+- `Player.setDefaultValue` và `Monster` gọi `ItemDAO.insert` khi tạo vật phẩm ngoài template.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@
 - Mọi `Item` đều có `id` riêng, kho đồ lưu được cả tiêu hao và vật liệu.
 - Xem thêm `ItemAndStatGuide.md` để mở rộng trang bị và chỉ số.
 
+## [1.0.25]
+
+### Thêm
+- `ItemDAO.insert` lưu vật phẩm tiêu hao và vật liệu mới vào bảng `Items` và `ItemStatMods`.
+- `PlayerDAO.saveInventory` bỏ qua hoặc tự chèn những item chưa có bản ghi trong cơ sở dữ liệu.
+- `Player` và `Monster` đăng ký vật phẩm tạo trực tiếp (không qua template) vào cơ sở dữ liệu.
+
 ## [1.0.20]
 
 ### Thêm

--- a/src/game/db/ItemDAO.java
+++ b/src/game/db/ItemDAO.java
@@ -97,6 +97,66 @@ public class ItemDAO {
         }
     }
 
+    /**
+     * Insert a new item definition into {@code Items} (and {@code ItemStatMods} if needed).
+     * Supports consumables ({@link HealthPotion}, {@link SpiritPotion}) and {@link MaterialItem}.
+     * For other types, this method simply checks if the item already exists.
+     *
+     * @param item item to persist
+     * @return {@code true} if the item exists or was inserted; {@code false} if unsupported
+     */
+    public static boolean insert(Item item) throws SQLException, ClassNotFoundException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            PreparedStatement sel = conn.prepareStatement(
+                "SELECT 1 FROM " + ITEMS + " WHERE ItemId = ?");
+            sel.setString(1, item.getId());
+            try (ResultSet rs = sel.executeQuery()) {
+                if (rs.next()) return true; // already exists
+            }
+
+            if (item instanceof HealthPotion hp) {
+                PreparedStatement ins = conn.prepareStatement(
+                    "INSERT INTO " + ITEMS + " (ItemId, Name, Type) VALUES (?,?,?)");
+                ins.setString(1, item.getId());
+                ins.setString(2, item.getName());
+                ins.setString(3, "HEALTH_POTION");
+                ins.executeUpdate();
+
+                PreparedStatement mod = conn.prepareStatement(
+                    "INSERT INTO " + ITEM_MODS + " (ItemId, Stat, Flat, PercentBonus) VALUES (?,?,?,0)");
+                mod.setString(1, item.getId());
+                mod.setString(2, Attr.HEALTH.name());
+                mod.setInt(3, hp.getHealthAmount());
+                mod.executeUpdate();
+                return true;
+            } else if (item instanceof SpiritPotion sp) {
+                PreparedStatement ins = conn.prepareStatement(
+                    "INSERT INTO " + ITEMS + " (ItemId, Name, Type) VALUES (?,?,?)");
+                ins.setString(1, item.getId());
+                ins.setString(2, item.getName());
+                ins.setString(3, "SPIRIT_POTION");
+                ins.executeUpdate();
+
+                PreparedStatement mod = conn.prepareStatement(
+                    "INSERT INTO " + ITEM_MODS + " (ItemId, Stat, Flat, PercentBonus) VALUES (?,?,?,0)");
+                mod.setString(1, item.getId());
+                mod.setString(2, Attr.SPIRIT.name());
+                mod.setInt(3, sp.getSpiritAmount());
+                mod.executeUpdate();
+                return true;
+            } else if (item instanceof MaterialItem) {
+                PreparedStatement ins = conn.prepareStatement(
+                    "INSERT INTO " + ITEMS + " (ItemId, Name, Type) VALUES (?,?,?)");
+                ins.setString(1, item.getId());
+                ins.setString(2, item.getName());
+                ins.setString(3, "MATERIAL");
+                ins.executeUpdate();
+                return true;
+            }
+            return false; // unsupported type without existing record
+        }
+    }
+
     private static String defaultIcon(EquipType type) {
         return switch (type) {
             case ARMOR -> "/data/item/equipment/armor.png";

--- a/src/game/db/PlayerDAO.java
+++ b/src/game/db/PlayerDAO.java
@@ -208,6 +208,13 @@ public class PlayerDAO {
         PreparedStatement ins = conn.prepareStatement(
             "INSERT INTO " + INV + " (PlayerId, ItemId, Quantity) VALUES (?,?,?)");
         for (Item it : bag.all()) {
+            try {
+                if (!ItemDAO.insert(it)) {
+                    continue; // skip items without DB definition
+                }
+            } catch (ClassNotFoundException e) {
+                throw new SQLException(e);
+            }
             ins.setString(1, pid);
             ins.setString(2, it.getId());
             ins.setInt(3, it.getQuantity());

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -42,6 +42,7 @@ import game.main.GamePanel;
 import game.util.CameraHelper;
 import game.util.UtilityTool;
 import game.db.PlayerDAO;
+import game.db.ItemDAO;
 
 public class Player extends GameActor implements DrawableEntity {
 	// Vị trí nhân vật trên màn hình (luôn ở giữa)
@@ -156,10 +157,18 @@ public class Player extends GameActor implements DrawableEntity {
             baseAtts.set(Attr.SPIRIT, 0);
 
             // Thêm vài item test: bình hồi máu & tinh thần
-            addItem(new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100));
+            var hp = new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3);
+            try { ItemDAO.insert(hp); } catch (Exception e) { e.printStackTrace(); }
+            addItem(hp);
+            var sp1 = new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100);
+            try { ItemDAO.insert(sp1); } catch (Exception e) { e.printStackTrace(); }
+            addItem(sp1);
+            var sp2 = new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100);
+            try { ItemDAO.insert(sp2); } catch (Exception e) { e.printStackTrace(); }
+            addItem(sp2);
+            var sp3 = new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100);
+            try { ItemDAO.insert(sp3); } catch (Exception e) { e.printStackTrace(); }
+            addItem(sp3);
 
             // Các sách công pháp và đan dược tu luyện để thử nghiệm
             var low = new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1);

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -51,8 +51,14 @@ public class HealthPotion extends Item {
     }
 
 	@Override
-	public BufferedImage getIcon() {
-		return icon;
-	}
+        public BufferedImage getIcon() {
+                return icon;
+        }
 
+    /**
+     * @return lượng máu hồi khi dùng bình này
+     */
+    public int getHealthAmount() {
+        return healthAmount;
+    }
 }

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -52,4 +52,11 @@ public class SpiritPotion extends Item {
     public BufferedImage getIcon() {
         return icon;
     }
+
+    /**
+     * @return lượng Spirit nhận được khi uống bình này
+     */
+    public int getSpiritAmount() {
+        return spiritAmount;
+    }
 }

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -14,6 +14,7 @@ import game.entity.GameActor;
 import game.entity.Entity;
 import game.enums.Attr;
 import game.main.GamePanel;
+import game.db.ItemDAO;
 
 /**
  * Lớp cơ sở cho tất cả quái vật trong game.
@@ -327,7 +328,9 @@ public abstract class Monster extends GameActor {
      */
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
-        list.add(new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1));
+        var hp = new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1);
+        try { ItemDAO.insert(hp); } catch (Exception e) { e.printStackTrace(); }
+        list.add(hp);
         return list;
     }
 

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,3 @@
-1. Chạy `ItemGenerator.createFromTemplate("TEMPLATE_ID")` và kiểm tra hàng mới trong bảng `Items` và `ItemStatMods`.
-2. Tạo nhân vật, nhặt vật phẩm tiêu hao và lưu game để kiểm tra `PlayerInventory` lưu mọi item.
-3. Đọc `ItemAndStatGuide.md` để thêm trang bị mới, sau đó dùng ItemDAO.load xác nhận xuất hiện.
+1. Tạo nhân vật mới và kiểm tra các bình HP_TEST, SP_TEST* xuất hiện trong bảng `Items` và `ItemStatMods`.
+2. Hạ gục quái để rơi `HP_DROP` rồi xác nhận bản ghi của bình này được tạo trong cơ sở dữ liệu.
+3. Lưu kho đồ chứa vật phẩm tùy chỉnh và xem `PlayerInventory` chỉ ghi các item có bản ghi trong `Items`.


### PR DESCRIPTION
## Summary
- add ItemDAO.insert to store consumables/materials into Items and ItemStatMods
- register newly created potions in Player and Monster so they have database records
- update PlayerDAO.saveInventory to persist only items with a backing DB entry

## Testing
- `javac $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68aecc123470832fa4bb294ccee467fa