### PR TITLE
Persist newly created consumables and materials

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,1 +1,1 @@
-Compiled all Java source files with `javac $(find src -name "*.java")` to ensure build succeeds.
+Compiled all Java source files with `javac $(find src -name "*.java")` to ensure build succeeds after adding `ItemDAO.insert` and inventory logic.

--- a/Change.txt
+++ b/Change.txt
@@ -106,3 +106,8 @@ Sửa lỗi và cải tiến:
 ## 1.0.24
 - Mỗi `Item` mang mã `id`, kho đồ lưu được cả tiêu hao và vật liệu.
 - Thêm `ItemTemplateDAO` và `ItemGenerator` tạo trang bị ngẫu nhiên từ mẫu.
+
+## 1.0.25
+- Thêm `ItemDAO.insert` lưu vật phẩm tiêu hao và vật liệu vào `Items`/`ItemStatMods`.
+- `Player.setDefaultValue` và quái vật rơi đồ gọi `ItemDAO.insert` khi tạo vật phẩm mới.
+- `PlayerDAO.saveInventory` bỏ qua hoặc tự chèn các item chưa có trong cơ sở dữ liệu.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 ## Cập nhật
 
+## [1.0.25]
+
+### Thêm
+- `ItemDAO.insert` lưu vật phẩm tiêu hao và vật liệu vào bảng `Items` và `ItemStatMods`.
+- `Player` và quái vật đăng ký các vật phẩm mới tạo vào cơ sở dữ liệu.
+- `PlayerDAO.saveInventory` bỏ qua hoặc tự chèn những vật phẩm chưa có bản ghi.
+
 ## [1.0.21]
 
 ### Thêm

--- a/src/game/db/ItemDAO.java
+++ b/src/game/db/ItemDAO.java
@@ -88,6 +88,59 @@ public class ItemDAO {
         return map;
     }
 
+    /**
+     * Insert a consumable or material item definition if it does not already exist.
+     *
+     * @param item item to persist
+     * @return {@code true} if the item exists or was inserted; {@code false} if unsupported
+     */
+    public static boolean insert(Item item) {
+        if (item == null || item.getId() == null) return false;
+        try (Connection conn = DBAccount.getConnectDB()) {
+            PreparedStatement check = conn.prepareStatement(
+                "SELECT 1 FROM " + ITEMS + " WHERE ItemId = ?");
+            check.setString(1, item.getId());
+            if (check.executeQuery().next()) return true; // already present
+
+            PreparedStatement insItem = conn.prepareStatement(
+                "INSERT INTO " + ITEMS + " (ItemId, Name, Type) VALUES (?,?,?)");
+            if (item instanceof HealthPotion hp) {
+                insItem.setString(1, hp.getId());
+                insItem.setString(2, hp.getName());
+                insItem.setString(3, "HEALTH_POTION");
+                insItem.executeUpdate();
+                PreparedStatement insMod = conn.prepareStatement(
+                    "INSERT INTO " + ITEM_MODS + " (ItemId, Stat, Flat) VALUES (?,?,?)");
+                insMod.setString(1, hp.getId());
+                insMod.setString(2, Attr.HEALTH.name());
+                insMod.setInt(3, hp.getHealthAmount());
+                insMod.executeUpdate();
+                return true;
+            } else if (item instanceof SpiritPotion sp) {
+                insItem.setString(1, sp.getId());
+                insItem.setString(2, sp.getName());
+                insItem.setString(3, "SPIRIT_POTION");
+                insItem.executeUpdate();
+                PreparedStatement insMod = conn.prepareStatement(
+                    "INSERT INTO " + ITEM_MODS + " (ItemId, Stat, Flat) VALUES (?,?,?)");
+                insMod.setString(1, sp.getId());
+                insMod.setString(2, Attr.SPIRIT.name());
+                insMod.setInt(3, sp.getSpiritAmount());
+                insMod.executeUpdate();
+                return true;
+            } else if (item instanceof MaterialItem m) {
+                insItem.setString(1, m.getId());
+                insItem.setString(2, m.getName());
+                insItem.setString(3, "MATERIAL");
+                insItem.executeUpdate();
+                return true;
+            }
+        } catch (SQLException | ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
     private static EquipType parseEquipType(String type) {
         if (type == null) return null;
         try {

--- a/src/game/db/PlayerDAO.java
+++ b/src/game/db/PlayerDAO.java
@@ -10,6 +10,7 @@ import game.entity.Player;
 import game.entity.item.EquipmentItem;
 import game.entity.item.Item;
 import game.entity.inventory.Inventory;
+import game.db.ItemDAO;
 import game.enums.Attr;
 import game.enums.EquipSlot;
 import game.entity.attributes.Attributes;
@@ -207,7 +208,13 @@ public class PlayerDAO {
         del.executeUpdate();
         PreparedStatement ins = conn.prepareStatement(
             "INSERT INTO " + INV + " (PlayerId, ItemId, Quantity) VALUES (?,?,?)");
+        PreparedStatement exist = conn.prepareStatement("SELECT 1 FROM Items WHERE ItemId=?");
         for (Item it : bag.all()) {
+            exist.setString(1, it.getId());
+            ResultSet rs = exist.executeQuery();
+            if (!rs.next()) {
+                if (!ItemDAO.insert(it)) continue; // skip if cannot persist
+            }
             ins.setString(1, pid);
             ins.setString(2, it.getId());
             ins.setInt(3, it.getQuantity());

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import game.entity.inventory.Inventory;
 import game.entity.item.Item;
 import game.entity.item.EquipmentItem;
+import game.db.ItemDAO;
 import game.entity.attributes.Attributes;
 import game.interfaces.DrawableEntity;
 import game.entity.monster.Monster;
@@ -156,10 +157,18 @@ public class Player extends GameActor implements DrawableEntity {
             baseAtts.set(Attr.SPIRIT, 0);
 
             // Thêm vài item test: bình hồi máu & tinh thần
-            addItem(new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100));
+            var hpTest = new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3);
+            ItemDAO.insert(hpTest);
+            addItem(hpTest);
+            var sp1 = new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100);
+            ItemDAO.insert(sp1);
+            addItem(sp1);
+            var sp2 = new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100);
+            ItemDAO.insert(sp2);
+            addItem(sp2);
+            var sp3 = new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100);
+            ItemDAO.insert(sp3);
+            addItem(sp3);
 
             // Các sách công pháp và đan dược tu luyện để thử nghiệm
             var low = new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1);
@@ -170,10 +179,18 @@ public class Player extends GameActor implements DrawableEntity {
             addItem(new game.entity.item.book.CultivationBook("BOOK_MID", mid));
             addItem(new game.entity.item.book.CultivationBook("BOOK_HIGH", high));
             addItem(new game.entity.item.book.CultivationBook("BOOK_TOP", top));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_LOW", "Đan hạ phẩm", 1, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_MID", "Đan trung phẩm", 2, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_HIGH", "Đan thượng phẩm", 3, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_TOP", "Đan cực phẩm", 4, 1));
+            var pillLow = new game.entity.item.elixir.CultivationPill("PILL_LOW", "Đan hạ phẩm", 1, 1);
+            ItemDAO.insert(pillLow);
+            addItem(pillLow);
+            var pillMid = new game.entity.item.elixir.CultivationPill("PILL_MID", "Đan trung phẩm", 2, 1);
+            ItemDAO.insert(pillMid);
+            addItem(pillMid);
+            var pillHigh = new game.entity.item.elixir.CultivationPill("PILL_HIGH", "Đan thượng phẩm", 3, 1);
+            ItemDAO.insert(pillHigh);
+            addItem(pillHigh);
+            var pillTop = new game.entity.item.elixir.CultivationPill("PILL_TOP", "Đan cực phẩm", 4, 1);
+            ItemDAO.insert(pillTop);
+            addItem(pillTop);
             
             EquipmentItem armor = new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
             armor.setBonus(Attr.DEF, 3);

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -50,9 +50,14 @@ public class HealthPotion extends Item {
         return this.getName().equals(other.getName()) && this.healthAmount == hp.healthAmount;
     }
 
-	@Override
-	public BufferedImage getIcon() {
-		return icon;
-	}
+        @Override
+        public BufferedImage getIcon() {
+                return icon;
+        }
+
+    /**
+     * @return lượng máu hồi khi sử dụng bình.
+     */
+    public int getHealthAmount() { return healthAmount; }
 
 }

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -52,4 +52,9 @@ public class SpiritPotion extends Item {
     public BufferedImage getIcon() {
         return icon;
     }
+
+    /**
+     * @return lượng Spirit cộng thêm khi sử dụng.
+     */
+    public int getSpiritAmount() { return spiritAmount; }
 }

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -12,6 +12,7 @@ import java.util.Random;
 
 import game.entity.GameActor;
 import game.entity.Entity;
+import game.db.ItemDAO;
 import game.enums.Attr;
 import game.main.GamePanel;
 
@@ -327,7 +328,9 @@ public abstract class Monster extends GameActor {
      */
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
-        list.add(new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1));
+        var hp = new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1);
+        ItemDAO.insert(hp);
+        list.add(hp);
         return list;
     }
 

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,3 @@
-1. Chạy `ItemGenerator.createFromTemplate("TEMPLATE_ID")` và kiểm tra hàng mới trong bảng `Items` và `ItemStatMods`.
-2. Tạo nhân vật, nhặt vật phẩm tiêu hao và lưu game để kiểm tra `PlayerInventory` lưu mọi item.
-3. Đọc `ItemAndStatGuide.md` để thêm trang bị mới, sau đó dùng ItemDAO.load xác nhận xuất hiện.
+1. Tạo nhân vật mới và kiểm tra các bình thuốc khởi tạo có bản ghi trong `Items` và `ItemStatMods`.
+2. Hạ gục quái để rơi bình máu, lưu game và xác nhận `PlayerInventory` ghi nhận bình đã rơi.
+3. Thêm một item không hỗ trợ (ví dụ sách) vào túi và lưu game để chắc chắn rằng `PlayerInventory` không bị lỗi khi bỏ qua item này.


### PR DESCRIPTION
## Summary
- add `ItemDAO.insert` to persist consumables and materials into `Items` and `ItemStatMods`
- register dropped or default items via `ItemDAO.insert`
- ensure `PlayerDAO.saveInventory` skips or inserts items missing from DB
- document changes in README and Change log

## Testing
- `javac $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68aecc1f2c6c832f9a280da03f5e1bd4