### PR TITLE
Add item persistence for consumables and materials

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,1 +1,3 @@
 Compiled all Java source files with `javac $(find src -name "*.java")` to ensure build succeeds.
+Verified new DAO methods compile by building the project.
+Runtime database tests were skipped because a SQL Server instance is not available in the environment.

--- a/Change.txt
+++ b/Change.txt
@@ -106,3 +106,8 @@ Sửa lỗi và cải tiến:
 ## 1.0.24
 - Mỗi `Item` mang mã `id`, kho đồ lưu được cả tiêu hao và vật liệu.
 - Thêm `ItemTemplateDAO` và `ItemGenerator` tạo trang bị ngẫu nhiên từ mẫu.
+
+## 1.0.25
+- Thêm `ItemDAO.insert` lưu vật phẩm tiêu hao và nguyên liệu mới vào bảng `Items`/`ItemStatMods`.
+- `PlayerDAO.saveInventory` tự tạo bản ghi còn thiếu hoặc bỏ qua item không hỗ trợ.
+- `Player` và `Monster` đăng ký vật phẩm mới vào cơ sở dữ liệu khi tạo bên ngoài template.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@
 - Mọi `Item` đều có `id` riêng, kho đồ lưu được cả tiêu hao và vật liệu.
 - Xem thêm `ItemAndStatGuide.md` để mở rộng trang bị và chỉ số.
 
+## [1.0.25]
+
+### Thêm
+- `ItemDAO.insert` lưu vật phẩm tiêu hao và nguyên liệu mới vào `Items`/`ItemStatMods`.
+- `PlayerDAO.saveInventory` tự thêm bản ghi thiếu hoặc bỏ qua loại không hỗ trợ.
+- `Player` và `Monster` đăng ký vật phẩm mới vào DB khi tạo ngoài template.
+
 ## [1.0.20]
 
 ### Thêm

--- a/src/game/db/ItemDAO.java
+++ b/src/game/db/ItemDAO.java
@@ -26,6 +26,70 @@ public class ItemDAO {
     private ItemDAO() {}
 
     /**
+     * Check if an item already exists in the {@code Items} table.
+     */
+    public static boolean exists(String itemId) throws SQLException, ClassNotFoundException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            return exists(conn, itemId);
+        }
+    }
+
+    public static boolean exists(Connection conn, String itemId) throws SQLException {
+        PreparedStatement ps = conn.prepareStatement("SELECT 1 FROM " + ITEMS + " WHERE ItemId=?");
+        ps.setString(1, itemId);
+        try (ResultSet rs = ps.executeQuery()) {
+            return rs.next();
+        }
+    }
+
+    /**
+     * Insert a new consumable or material item into {@code Items} and
+     * {@code ItemStatMods}. Unsupported item types return {@code false}.
+     */
+    public static boolean insert(Item item) throws SQLException, ClassNotFoundException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            return insert(conn, item);
+        }
+    }
+
+    /** Insert using an existing connection. */
+    public static boolean insert(Connection conn, Item item) throws SQLException {
+        if (item == null) return false;
+        if (exists(conn, item.getId())) return true; // already persisted
+
+        String type;
+        EnumMap<Attr, Integer> mods = new EnumMap<>(Attr.class);
+        if (item instanceof HealthPotion hp) {
+            type = "HEALTH_POTION";
+            mods.put(Attr.HEALTH, hp.getHealthAmount());
+        } else if (item instanceof SpiritPotion sp) {
+            type = "SPIRIT_POTION";
+            mods.put(Attr.SPIRIT, sp.getSpiritAmount());
+        } else if (item instanceof MaterialItem) {
+            type = "MATERIAL";
+        } else {
+            return false; // unsupported type
+        }
+
+        PreparedStatement ins = conn.prepareStatement(
+            "INSERT INTO " + ITEMS + " (ItemId, Name, Type) VALUES (?,?,?)");
+        ins.setString(1, item.getId());
+        ins.setString(2, item.getName());
+        ins.setString(3, type);
+        ins.executeUpdate();
+
+        for (Map.Entry<Attr, Integer> e : mods.entrySet()) {
+            PreparedStatement mod = conn.prepareStatement(
+                "INSERT INTO " + ITEM_MODS + " (ItemId, Stat, Flat, PercentBonus) VALUES (?,?,?,0)");
+            mod.setString(1, item.getId());
+            mod.setString(2, e.getKey().name());
+            mod.setInt(3, e.getValue());
+            mod.executeUpdate();
+        }
+        return true;
+    }
+
+    /**
      * Load an item by id. Supports equipment types; other item types are
      * returned as null.
      *

--- a/src/game/db/PlayerDAO.java
+++ b/src/game/db/PlayerDAO.java
@@ -208,6 +208,17 @@ public class PlayerDAO {
         PreparedStatement ins = conn.prepareStatement(
             "INSERT INTO " + INV + " (PlayerId, ItemId, Quantity) VALUES (?,?,?)");
         for (Item it : bag.all()) {
+            boolean exists = ItemDAO.exists(conn, it.getId());
+            if (!exists) {
+                try {
+                    if (!ItemDAO.insert(conn, it)) {
+                        continue; // skip unsupported items
+                    }
+                } catch (SQLException ex) {
+                    ex.printStackTrace();
+                    continue;
+                }
+            }
             ins.setString(1, pid);
             ins.setString(2, it.getId());
             ins.setInt(3, it.getQuantity());

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -42,6 +42,7 @@ import game.main.GamePanel;
 import game.util.CameraHelper;
 import game.util.UtilityTool;
 import game.db.PlayerDAO;
+import game.db.ItemDAO;
 
 public class Player extends GameActor implements DrawableEntity {
 	// Vị trí nhân vật trên màn hình (luôn ở giữa)
@@ -156,54 +157,54 @@ public class Player extends GameActor implements DrawableEntity {
             baseAtts.set(Attr.SPIRIT, 0);
 
             // Thêm vài item test: bình hồi máu & tinh thần
-            addItem(new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100));
-            addItem(new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100));
+            addItemAndStore(new game.entity.item.elixir.HealthPotion("HP_TEST", 50, 3));
+            addItemAndStore(new game.entity.item.elixir.SpiritPotion("SP_TEST1", 200, 100));
+            addItemAndStore(new game.entity.item.elixir.SpiritPotion("SP_TEST2", 2000, 100));
+            addItemAndStore(new game.entity.item.elixir.SpiritPotion("SP_TEST3", 20000, 100));
 
             // Các sách công pháp và đan dược tu luyện để thử nghiệm
             var low = new CultivationTechnique("Công pháp hạ phẩm", SkillGrade.HA, 1, 1);
             var mid = new CultivationTechnique("Công pháp trung phẩm", SkillGrade.TRUNG, 1, 2);
             var high = new CultivationTechnique("Công pháp thượng phẩm", SkillGrade.THUONG, 1, 3);
             var top = new CultivationTechnique("Công pháp cực phẩm", SkillGrade.CUC, 1, 5);
-            addItem(new game.entity.item.book.CultivationBook("BOOK_LOW", low));
-            addItem(new game.entity.item.book.CultivationBook("BOOK_MID", mid));
-            addItem(new game.entity.item.book.CultivationBook("BOOK_HIGH", high));
-            addItem(new game.entity.item.book.CultivationBook("BOOK_TOP", top));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_LOW", "Đan hạ phẩm", 1, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_MID", "Đan trung phẩm", 2, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_HIGH", "Đan thượng phẩm", 3, 1));
-            addItem(new game.entity.item.elixir.CultivationPill("PILL_TOP", "Đan cực phẩm", 4, 1));
+            addItemAndStore(new game.entity.item.book.CultivationBook("BOOK_LOW", low));
+            addItemAndStore(new game.entity.item.book.CultivationBook("BOOK_MID", mid));
+            addItemAndStore(new game.entity.item.book.CultivationBook("BOOK_HIGH", high));
+            addItemAndStore(new game.entity.item.book.CultivationBook("BOOK_TOP", top));
+            addItemAndStore(new game.entity.item.elixir.CultivationPill("PILL_LOW", "Đan hạ phẩm", 1, 1));
+            addItemAndStore(new game.entity.item.elixir.CultivationPill("PILL_MID", "Đan trung phẩm", 2, 1));
+            addItemAndStore(new game.entity.item.elixir.CultivationPill("PILL_HIGH", "Đan thượng phẩm", 3, 1));
+            addItemAndStore(new game.entity.item.elixir.CultivationPill("PILL_TOP", "Đan cực phẩm", 4, 1));
             
             EquipmentItem armor = new EquipmentItem("Áo giáp", "+3 DEF", "/data/item/equipment/armor.png", EquipType.ARMOR);
             armor.setBonus(Attr.DEF, 3);
-            addItem(armor);
+            addItemAndStore(armor);
             EquipmentItem helmet = new EquipmentItem("Mũ sắt", "+3 DEF", "/data/item/equipment/helmet.png", EquipType.HELMET);
             helmet.setBonus(Attr.DEF, 3);
-            addItem(helmet);
+            addItemAndStore(helmet);
             EquipmentItem pants = new EquipmentItem("Quần vải", "+3 DEF", "/data/item/equipment/pants.png", EquipType.PANTS);
             pants.setBonus(Attr.DEF, 3);
-            addItem(pants);
+            addItemAndStore(pants);
             EquipmentItem shoes = new EquipmentItem("Giày da", "+3 DEF", "/data/item/equipment/shoes.png", EquipType.SHOES);
             shoes.setBonus(Attr.DEF, 3);
-            addItem(shoes);
+            addItemAndStore(shoes);
             EquipmentItem sword1 = new EquipmentItem("Kiếm gỗ", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
             sword1.setBonus(Attr.ATTACK, 10);
-            addItem(sword1);
+            addItemAndStore(sword1);
             EquipmentItem sword2 = new EquipmentItem("Kiếm sắt", "+10 ATTACK", "/data/item/equipment/sword.png", EquipType.WEAPON);
             sword2.setBonus(Attr.ATTACK, 10);
-            addItem(sword2);
+            addItemAndStore(sword2);
             EquipmentItem necklace = new EquipmentItem("Dây chuyền", "+10 SOULD", "/data/item/equipment/ring.png", EquipType.NECKLACE);
             necklace.setBonus(Attr.SOULD, 10);
-            addItem(necklace);
+            addItemAndStore(necklace);
             EquipmentItem ring1 = new EquipmentItem("Nhẫn đá", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
             ring1.setBonus(Attr.SOULD, 0);
-            addItem(ring1);
+            addItemAndStore(ring1);
             EquipmentItem ring2 = new EquipmentItem("Nhẫn bạc", "+10 ô kho", "/data/item/equipment/ring.png", EquipType.RING);
             ring2.setBonus(Attr.SOULD, 0);
-            addItem(ring2);
+            addItemAndStore(ring2);
             EquipmentItem amulet = new EquipmentItem("Bùa hộ mệnh", "Chưa có tác dụng", "/data/item/equipment/d_1.png", EquipType.AMULET);
-            addItem(amulet);
+            addItemAndStore(amulet);
 
             saveState();
         }
@@ -467,6 +468,17 @@ public class Player extends GameActor implements DrawableEntity {
         boolean added = bag.add(item);
         PlayerDAO.save(this);
         return added;
+    }
+
+    // Tạo item mới, ghi vào DB nếu cần rồi thêm vào túi
+    private void addItemAndStore(Item item) {
+        try {
+            ItemDAO.insert(item);
+        } catch (Exception e) {
+            // Nếu không lưu được vẫn tiếp tục thêm vào túi để tránh gián đoạn
+            e.printStackTrace();
+        }
+        addItem(item);
     }
 
     // Sử dụng item

--- a/src/game/entity/item/elixir/HealthPotion.java
+++ b/src/game/entity/item/elixir/HealthPotion.java
@@ -50,9 +50,15 @@ public class HealthPotion extends Item {
         return this.getName().equals(other.getName()) && this.healthAmount == hp.healthAmount;
     }
 
-	@Override
-	public BufferedImage getIcon() {
-		return icon;
-	}
+    @Override
+    public BufferedImage getIcon() {
+        return icon;
+    }
 
+    /**
+     * @return amount of health restored when the potion is used.
+     */
+    public int getHealthAmount() {
+        return healthAmount;
+    }
 }

--- a/src/game/entity/item/elixir/SpiritPotion.java
+++ b/src/game/entity/item/elixir/SpiritPotion.java
@@ -52,4 +52,11 @@ public class SpiritPotion extends Item {
     public BufferedImage getIcon() {
         return icon;
     }
+
+    /**
+     * @return amount of spirit granted when used.
+     */
+    public int getSpiritAmount() {
+        return spiritAmount;
+    }
 }

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -14,6 +14,7 @@ import game.entity.GameActor;
 import game.entity.Entity;
 import game.enums.Attr;
 import game.main.GamePanel;
+import game.db.ItemDAO;
 
 /**
  * Lớp cơ sở cho tất cả quái vật trong game.
@@ -327,7 +328,13 @@ public abstract class Monster extends GameActor {
      */
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
-        list.add(new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1));
+        var potion = new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1);
+        try {
+            ItemDAO.insert(potion);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        list.add(potion);
         return list;
     }
 

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,3 @@
-1. Chạy `ItemGenerator.createFromTemplate("TEMPLATE_ID")` và kiểm tra hàng mới trong bảng `Items` và `ItemStatMods`.
-2. Tạo nhân vật, nhặt vật phẩm tiêu hao và lưu game để kiểm tra `PlayerInventory` lưu mọi item.
-3. Đọc `ItemAndStatGuide.md` để thêm trang bị mới, sau đó dùng ItemDAO.load xác nhận xuất hiện.
+1. Tạo nhân vật mới, kiểm tra các bình HP/SP mặc định được thêm vào bảng `Items` và `ItemStatMods`.
+2. Hạ gục quái vật để rơi bình máu, xác minh item xuất hiện trong `Items` nếu chưa có.
+3. Lưu game và kiểm tra `PlayerInventory` chỉ chứa các item đã có bản ghi hợp lệ.


### PR DESCRIPTION
## Summary
- introduce ItemDAO.insert to persist consumables and materials into Items/ItemStatMods
- register new items when created by Player defaults and monster drops
- ensure PlayerDAO.saveInventory inserts missing items or skips unsupported ones

## Testing
- `javac -d /tmp/out @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68aecc212bf8832f95f0def4bdeda637