### PR TITLE
Cache player state in memory before periodic DB flush

### DIFF
--- a/AiTest.txt
+++ b/AiTest.txt
@@ -1,3 +1,3 @@
-Compiled all Java source files with `javac $(find src -name "*.java")` to ensure build succeeds.
-Verified new DAO methods compile by building the project.
-Runtime database tests were skipped because a SQL Server instance is not available in the environment.
+- Compiled all Java source files with `javac $(find src -name "*.java")`.
+- Searched codebase to ensure only periodic/exit flush writes to database.
+- Database runtime tests skipped due to missing SQL Server instance.

--- a/Change.txt
+++ b/Change.txt
@@ -111,3 +111,9 @@ Sửa lỗi và cải tiến:
 - Thêm `ItemDAO.insert` lưu vật phẩm tiêu hao và nguyên liệu mới vào bảng `Items`/`ItemStatMods`.
 - `PlayerDAO.saveInventory` tự tạo bản ghi còn thiếu hoặc bỏ qua item không hỗ trợ.
 - `Player` và `Monster` đăng ký vật phẩm mới vào cơ sở dữ liệu khi tạo bên ngoài template.
+
+## 1.0.26
+- Chuyển cơ chế lưu trực tiếp sang lưu tạm trong bộ nhớ rồi flush xuống database
+  mỗi 10 phút hoặc khi thoát game.
+- Loại bỏ các lời gọi lưu DB ngay lập tức trong `Player` và `Monster`.
+- Cập nhật README, AiTest.txt và test.txt mô tả cơ chế mới và cách kiểm tra.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@
 - `PlayerDAO.saveInventory` tự thêm bản ghi thiếu hoặc bỏ qua loại không hỗ trợ.
 - `Player` và `Monster` đăng ký vật phẩm mới vào DB khi tạo ngoài template.
 
+## [1.0.26]
+
+### Thay đổi
+- Chuyển cơ chế lưu trực tiếp sang lưu tạm trong bộ nhớ và chỉ ghi xuống cơ sở dữ liệu
+  mỗi 10 phút hoặc khi thoát game.
+
 ## [1.0.20]
 
 ### Thêm

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -93,6 +93,8 @@ public class Player extends GameActor implements DrawableEntity {
         t.setDaemon(true);
         return t;
     });
+    /** Cho biết hồ sơ đã thay đổi kể từ lần lưu gần nhất hay chưa. */
+    private volatile boolean dirty = false;
 
     // Danh sách công pháp đã học
     private final List<CultivationTechnique> techniques = new ArrayList<>();
@@ -205,8 +207,6 @@ public class Player extends GameActor implements DrawableEntity {
             addItemAndStore(ring2);
             EquipmentItem amulet = new EquipmentItem("Bùa hộ mệnh", "Chưa có tác dụng", "/data/item/equipment/d_1.png", EquipType.AMULET);
             addItemAndStore(amulet);
-
-            saveState();
         }
 
         refreshStats();
@@ -458,26 +458,20 @@ public class Player extends GameActor implements DrawableEntity {
         BufferedImage image = null;
         try {
             image = ImageIO.read(Objects.requireNonNull(getClass().getResourceAsStream(imagePath + ".png")));
-        } 
+        }
         catch (IOException e) { e.printStackTrace(); }
         return UtilityTool.scaleImage(image, gp.getTileSize(), gp.getTileSize());
     }
     
-    // Thêm item vào túi và lưu, trả về true nếu thành công
+    // Thêm item vào túi và đánh dấu cần lưu, trả về true nếu thành công
     public boolean addItem(Item item) {
         boolean added = bag.add(item);
-        PlayerDAO.save(this);
+        if (added) markDirty();
         return added;
     }
 
-    // Tạo item mới, ghi vào DB nếu cần rồi thêm vào túi
+    // Tạo item mới rồi thêm vào túi (ghi DB sẽ thực hiện khi flush)
     private void addItemAndStore(Item item) {
-        try {
-            ItemDAO.insert(item);
-        } catch (Exception e) {
-            // Nếu không lưu được vẫn tiếp tục thêm vào túi để tránh gián đoạn
-            e.printStackTrace();
-        }
         addItem(item);
     }
 
@@ -485,7 +479,7 @@ public class Player extends GameActor implements DrawableEntity {
     public void useItem(Item i) {
         i.use(this);
         if(i.getQuantity() == 0) bag.remove(i);
-        saveState();
+        markDirty();
     }
 
     /**
@@ -507,9 +501,8 @@ public class Player extends GameActor implements DrawableEntity {
     /** Người chơi học một công pháp mới. */
     public void learnSkill(CultivationTechnique tech) {
         techniques.add(tech);
-        // Lưu lại tiến trình ngay sau khi học để đảm bảo
-        // công pháp tồn tại khi thoát game.
-        saveState();
+        // Đánh dấu để flush ra DB ở lần lưu định kỳ/thoát game.
+        markDirty();
     }
 
     // Công pháp được gán vào phím nhanh (tạm thời lưu 1 kỹ năng).
@@ -623,7 +616,7 @@ public class Player extends GameActor implements DrawableEntity {
         // Cập nhật max Spirit cho HUD
         baseAtts.setMax(Attr.SPIRIT, spiritToNextLevel);
         refreshStats();
-        saveState();
+        markDirty();
     }
 
     /**
@@ -742,18 +735,24 @@ public class Player extends GameActor implements DrawableEntity {
         realmLog.add(sb.toString());
     }
 
-    public synchronized void saveState() {
+    /** Đánh dấu hồ sơ cần lưu ra DB. */
+    private void markDirty() { dirty = true; }
+
+    /** Ghi trạng thái hiện tại xuống DB nếu có thay đổi. */
+    public synchronized void flushIfDirty() {
+        if (!dirty) return;
         logRealmState();
         PlayerDAO.save(this);
+        dirty = false;
     }
 
     private void startAutoSave() {
-        autoSaveExecutor.scheduleAtFixedRate(this::saveState, 10, 10, TimeUnit.MINUTES);
+        autoSaveExecutor.scheduleAtFixedRate(this::flushIfDirty, 10, 10, TimeUnit.MINUTES);
     }
 
     public void stopAutoSave() {
         autoSaveExecutor.shutdownNow();
-        saveState();
+        flushIfDirty();
     }
 
     private Physique parsePhysique(String display) {

--- a/src/game/entity/monster/Monster.java
+++ b/src/game/entity/monster/Monster.java
@@ -14,7 +14,6 @@ import game.entity.GameActor;
 import game.entity.Entity;
 import game.enums.Attr;
 import game.main.GamePanel;
-import game.db.ItemDAO;
 
 /**
  * Lớp cơ sở cho tất cả quái vật trong game.
@@ -329,11 +328,7 @@ public abstract class Monster extends GameActor {
     protected java.util.List<game.entity.item.Item> createDropItems() {
         java.util.List<game.entity.item.Item> list = new java.util.ArrayList<>();
         var potion = new game.entity.item.elixir.HealthPotion("HP_DROP", 30, 1);
-        try {
-            ItemDAO.insert(potion);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        // Việc ghi item xuống DB sẽ được thực hiện khi người chơi nhặt và flush hồ sơ.
         list.add(potion);
         return list;
     }

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,5 @@
-1. Tạo nhân vật mới, kiểm tra các bình HP/SP mặc định được thêm vào bảng `Items` và `ItemStatMods`.
-2. Hạ gục quái vật để rơi bình máu, xác minh item xuất hiện trong `Items` nếu chưa có.
-3. Lưu game và kiểm tra `PlayerInventory` chỉ chứa các item đã có bản ghi hợp lệ.
+1. Khởi động game, thêm hoặc sử dụng một vài vật phẩm rồi thoát ngay lập tức;
+   kiểm tra trong database rằng thay đổi đã được lưu nhờ cơ chế flush khi thoát.
+2. Chạy game lại và xác nhận dữ liệu người chơi được tải đúng từ database.
+3. Để game chạy hơn 10 phút mà không thoát; sau đó kiểm tra database để
+   xác nhận auto-save định kỳ hoạt động.


### PR DESCRIPTION
## Summary
- remove immediate database writes and cache player changes in-memory
- periodically flush player state to database every 10 minutes or on shutdown
- update docs and tests to reflect new save mechanism

## Testing
- `javac -d /tmp/out $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68aefb7cbac0832f99a25ced12e3fb0e