### PR TITLE
Cache player state and relax item FK

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -95,3 +95,7 @@ Sửa lỗi và cải tiến:
 - Đổi tên cột `Percent` thành `PercentBonus` trong `sql/game_db_core_schema.sql` để tránh từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa có.
 - Cập nhật README hướng dẫn chạy script trước khi khởi động game.
+
+## 1.0.23
+- Player lưu trạng thái tạm trong bộ nhớ và ghi xuống database mỗi 10 phút hoặc khi thoát.
+- Bảng `PlayerInventory` và `PlayerEquipment` bỏ ràng buộc khoá ngoại tới `Items` để thêm item mới không lỗi.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 - Đổi tên cột `ItemStatMods.Percent` thành `PercentBonus` để tránh xung đột từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa tồn tại.
 
+## [1.0.23]
+
+### Sửa đổi
+- `Player` lưu trạng thái tạm và ghi xuống database định kỳ 10 phút và khi thoát.
+- Bảng `PlayerInventory` và `PlayerEquipment` bỏ ràng buộc khoá ngoại tới `Items` để không lỗi khi xuất hiện item mới.
+
 ## [1.0.20]
 
 ### Thêm

--- a/sql/game_db_core_schema.sql
+++ b/sql/game_db_core_schema.sql
@@ -87,9 +87,8 @@ CREATE TABLE dbo.PlayerInventory (
   Quantity INT NOT NULL CONSTRAINT CK_PlayerInventory_Quantity CHECK (Quantity >= 0),
   CONSTRAINT PK_PlayerInventory PRIMARY KEY (PlayerId, ItemId),
   CONSTRAINT FK_PlayerInventory_Player FOREIGN KEY (PlayerId)
-    REFERENCES dbo.Players(PlayerId) ON DELETE CASCADE,
-  CONSTRAINT FK_PlayerInventory_Item FOREIGN KEY (ItemId)
-    REFERENCES dbo.Items(ItemId)
+    REFERENCES dbo.Players(PlayerId) ON DELETE CASCADE
+  -- Bỏ ràng buộc với bảng Items để tránh lỗi khi có item mới chưa được định nghĩa
 );
 
 -- Slot hợp lệ gợi ý: ARMOR, HELMET, PANTS, SHOES, WEAPON1, WEAPON2, NECKLACE, RING1, RING2, AMULET
@@ -99,9 +98,8 @@ CREATE TABLE dbo.PlayerEquipment (
   ItemId NVARCHAR(64) NULL,          -- NULL = none
   CONSTRAINT PK_PlayerEquipment PRIMARY KEY (PlayerId, Slot),
   CONSTRAINT FK_PlayerEquipment_Player FOREIGN KEY (PlayerId)
-    REFERENCES dbo.Players(PlayerId) ON DELETE CASCADE,
-  CONSTRAINT FK_PlayerEquipment_Item FOREIGN KEY (ItemId)
-    REFERENCES dbo.Items(ItemId)
+    REFERENCES dbo.Players(PlayerId) ON DELETE CASCADE
+  -- Không kiểm tra khoá ngoại ItemId để việc thêm item mới không bị chặn
 );
 GO
 

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -444,7 +444,7 @@ public class Player extends GameActor implements DrawableEntity {
     // Thêm item vào túi và lưu, trả về true nếu thành công
     public boolean addItem(Item item) {
         boolean added = bag.add(item);
-        saveProfile();
+        saveState();
         return added;
     }
 
@@ -709,22 +709,62 @@ public class Player extends GameActor implements DrawableEntity {
         realmLog.add(sb.toString());
     }
 
+    private String pendingProfile;
+
     public synchronized void saveState() {
         logRealmState();
-        saveProfile();
+        pendingProfile = buildProfileData();
     }
 
     private void startAutoSave() {
-        autoSaveExecutor.scheduleAtFixedRate(this::saveState, 10, 10, TimeUnit.MINUTES);
+        saveState();
+        autoSaveExecutor.scheduleAtFixedRate(this::persistProfile, 10, 10, TimeUnit.MINUTES);
     }
 
     public void stopAutoSave() {
         autoSaveExecutor.shutdownNow();
-        saveState();
+        persistProfile();
     }
 
-    /** Persist current player profile to SQL Server. */
-    private void saveProfile() {
+    private String buildProfileData() {
+        List<String> lines = new ArrayList<>();
+        lines.add("CREATION_DATE: " + creationDate.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+        String items = bag.all().stream()
+                .map(it -> it.getName() + " (" + it.getQuantity() + ")")
+                .collect(Collectors.joining(", "));
+        lines.add("Itemcủa nhân vật: " + items);
+
+        lines.add("===EQUIPMENT===");
+        EquipSlot[] order = {
+            EquipSlot.ARMOR,
+            EquipSlot.HELMET,
+            EquipSlot.PANTS,
+            EquipSlot.SHOES,
+            EquipSlot.WEAPON1,
+            EquipSlot.WEAPON2,
+            EquipSlot.NECKLACE,
+            EquipSlot.RING1,
+            EquipSlot.RING2,
+            EquipSlot.AMULET
+        };
+        for (EquipSlot slot : order) {
+            EquipmentItem eq = equipment.get(slot);
+            if (eq != null) {
+                lines.add("- " + slot.name() + ": " + eq.getId() + "|" + eq.getName() + "|" + eq.getDecription());
+            } else {
+                lines.add("- " + slot.name() + ": none");
+            }
+        }
+
+        lines.addAll(realmLog);
+        return String.join("\n", lines);
+    }
+
+    /** Persist cached profile to SQL Server. */
+    private void persistProfile() {
+        if (pendingProfile == null) {
+            pendingProfile = buildProfileData();
+        }
         try (Connection conn = DBAccount.getConnectDB()) {
             try (Statement st = conn.createStatement()) {
                 st.execute(
@@ -735,38 +775,6 @@ public class Player extends GameActor implements DrawableEntity {
                 );
             }
 
-            List<String> lines = new ArrayList<>();
-            lines.add("CREATION_DATE: " + creationDate.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
-            String items = bag.all().stream()
-                    .map(it -> it.getName() + " (" + it.getQuantity() + ")")
-                    .collect(Collectors.joining(", "));
-            lines.add("Itemcủa nhân vật: " + items);
-
-            lines.add("===EQUIPMENT===");
-            EquipSlot[] order = {
-                EquipSlot.ARMOR,
-                EquipSlot.HELMET,
-                EquipSlot.PANTS,
-                EquipSlot.SHOES,
-                EquipSlot.WEAPON1,
-                EquipSlot.WEAPON2,
-                EquipSlot.NECKLACE,
-                EquipSlot.RING1,
-                EquipSlot.RING2,
-                EquipSlot.AMULET
-            };
-            for (EquipSlot slot : order) {
-                EquipmentItem eq = equipment.get(slot);
-                if (eq != null) {
-                    lines.add("- " + slot.name() + ": " + eq.getId() + "|" + eq.getName() + "|" + eq.getDecription());
-                } else {
-                    lines.add("- " + slot.name() + ": none");
-                }
-            }
-
-            lines.addAll(realmLog);
-            String profileData = String.join("\n", lines);
-
             String sql = "MERGE " + PROFILE_TABLE + " AS target " +
                     "USING (SELECT ? AS name, ? AS profile) AS src " +
                     "ON target.name = src.name " +
@@ -775,7 +783,7 @@ public class Player extends GameActor implements DrawableEntity {
 
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setString(1, getName());
-                ps.setString(2, profileData);
+                ps.setString(2, pendingProfile);
                 ps.executeUpdate();
             }
         } catch (ClassNotFoundException | SQLException e) {


### PR DESCRIPTION
## Summary
- Cache player profile in memory and flush to SQL Server on a 10‑minute timer and on shutdown
- Drop item foreign key constraints in `PlayerInventory`/`PlayerEquipment` to allow new item IDs
- Document new persistence behavior and schema changes

## Testing
- `javac @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68af0feea408832fa193d347b4e11afb