### PR TITLE
Persist player stats via DAO layer

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -106,3 +106,6 @@ Sửa lỗi và cải tiến:
 ## 1.0.25
 - Bảng `Players` lưu thể chất `Physique` của người chơi.
 - `PlayerDao` và `Player` đọc/ghi thể chất để duy trì tối đa tầng và các hiệu ứng đặc biệt sau khi tải lại.
+
+## 1.0.26
+- Thêm phương thức `getFullRealmName` trong `PlayerDao.PlayerRecord` trả về tên cảnh giới kèm tiểu cảnh giới (ví dụ: "Luyện thể tầng 10").

--- a/Change.txt
+++ b/Change.txt
@@ -102,3 +102,7 @@ Sửa lỗi và cải tiến:
 
 ## 1.0.24
 - Lưu thêm `RealmStage` vào bảng `Players` và đọc/ghi giá trị này khi tải hoặc lưu nhân vật.
+
+## 1.0.25
+- Bảng `Players` lưu thể chất `Physique` của người chơi.
+- `PlayerDao` và `Player` đọc/ghi thể chất để duy trì tối đa tầng và các hiệu ứng đặc biệt sau khi tải lại.

--- a/Change.txt
+++ b/Change.txt
@@ -99,3 +99,6 @@ Sửa lỗi và cải tiến:
 ## 1.0.23
 - Thêm các lớp DAO tương tác với bảng `Players`, `PlayerBaseStats` và `PlayerRuntime` để lưu chỉ số nhân vật.
 - `Player.saveState` và `Player.loadProfile` sử dụng các DAO này thay cho chuỗi `PlayerProfile`.
+
+## 1.0.24
+- Lưu thêm `RealmStage` vào bảng `Players` và đọc/ghi giá trị này khi tải hoặc lưu nhân vật.

--- a/Change.txt
+++ b/Change.txt
@@ -95,3 +95,7 @@ Sửa lỗi và cải tiến:
 - Đổi tên cột `Percent` thành `PercentBonus` trong `sql/game_db_core_schema.sql` để tránh từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa có.
 - Cập nhật README hướng dẫn chạy script trước khi khởi động game.
+
+## 1.0.23
+- Thêm các lớp DAO tương tác với bảng `Players`, `PlayerBaseStats` và `PlayerRuntime` để lưu chỉ số nhân vật.
+- `Player.saveState` và `Player.loadProfile` sử dụng các DAO này thay cho chuỗi `PlayerProfile`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@
 - Bảng `Players` lưu thể chất (`Physique`) của người chơi.
 - `PlayerDao` và `Player` đọc/ghi cột `Physique` để giữ nguyên thể chất khi tải lại nhân vật.
 
+## [1.0.26]
+
+### Thêm
+- `PlayerDao.PlayerRecord` cung cấp phương thức `getFullRealmName()` trả về chuỗi như "Luyện thể tầng 10" kết hợp `Realm` và `RealmStage`.
+
 ## [1.0.20]
 
 ### Thêm

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 	
 ## Tính năng
 
-- Thuộc tính nhân vật được lưu vào SQL Server thông qua các bảng `Players`, `PlayerBaseStats` và `PlayerRuntime`.
+- Thuộc tính nhân vật được lưu vào SQL Server thông qua các bảng `Players` (cảnh giới, thể chất), `PlayerBaseStats` và `PlayerRuntime`.
 
 ## Cập nhật
 
@@ -29,6 +29,12 @@
 
 ### Sửa đổi
 - Bảng `Players` lưu thêm cột `RealmStage` để giữ tiểu cảnh giới hiện tại của người chơi.
+
+## [1.0.25]
+
+### Thêm
+- Bảng `Players` lưu thể chất (`Physique`) của người chơi.
+- `PlayerDao` và `Player` đọc/ghi cột `Physique` để giữ nguyên thể chất khi tải lại nhân vật.
 
 ## [1.0.20]
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
 - Các lớp DAO (`PlayerDao`, `PlayerBaseStatsDao`, `PlayerRuntimeDao`) lưu trữ và đọc thuộc tính nhân vật từ database.
 - `Player.saveState` và `Player.loadProfile` sử dụng các bảng `Players`, `PlayerBaseStats`, `PlayerRuntime` thay cho chuỗi profile.
 
+## [1.0.24]
+
+### Sửa đổi
+- Bảng `Players` lưu thêm cột `RealmStage` để giữ tiểu cảnh giới hiện tại của người chơi.
+
 ## [1.0.20]
 
 ### Thêm

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 	
 ## Tính năng
 
+- Thuộc tính nhân vật được lưu vào SQL Server thông qua các bảng `Players`, `PlayerBaseStats` và `PlayerRuntime`.
+
 ## Cập nhật
 
 ## [1.0.21]
@@ -16,6 +18,12 @@
 ### Sửa đổi
 - Đổi tên cột `ItemStatMods.Percent` thành `PercentBonus` để tránh xung đột từ khóa SQL.
 - Thêm script `sql/create_player_profile.sql` tạo bảng `PlayerProfile` nếu chưa tồn tại.
+
+## [1.0.23]
+
+### Thêm
+- Các lớp DAO (`PlayerDao`, `PlayerBaseStatsDao`, `PlayerRuntimeDao`) lưu trữ và đọc thuộc tính nhân vật từ database.
+- `Player.saveState` và `Player.loadProfile` sử dụng các bảng `Players`, `PlayerBaseStats`, `PlayerRuntime` thay cho chuỗi profile.
 
 ## [1.0.20]
 

--- a/sql/game_db_core_schema.sql
+++ b/sql/game_db_core_schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE dbo.Players (
   Name NVARCHAR(64) NOT NULL UNIQUE,
   Realm NVARCHAR(64) NULL,
   RealmStage INT NOT NULL DEFAULT 0,
+  Physique NVARCHAR(64) NOT NULL DEFAULT 'NORMAL',
   CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
 );
 
@@ -147,8 +148,8 @@ GO
    6) Tạo 1 player mẫu để test
    ---------------------------- */
 DECLARE @pid UNIQUEIDENTIFIER = NEWID();
-INSERT INTO dbo.Players (PlayerId, Name, Realm, RealmStage)
-VALUES (@pid, N'Nguyeen_pro', N'phàm nhân', 0);
+INSERT INTO dbo.Players (PlayerId, Name, Realm, RealmStage, Physique)
+VALUES (@pid, N'Nguyeen_pro', N'phàm nhân', 0, N'NORMAL');
 
 INSERT INTO dbo.PlayerBaseStats (PlayerId, Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength)
 VALUES (@pid, 5, 4, 100, 100, 5, 0, 1000, 1);

--- a/sql/game_db_core_schema.sql
+++ b/sql/game_db_core_schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE dbo.Players (
   PlayerId UNIQUEIDENTIFIER NOT NULL CONSTRAINT PK_Players PRIMARY KEY DEFAULT NEWID(),
   Name NVARCHAR(64) NOT NULL UNIQUE,
   Realm NVARCHAR(64) NULL,
+  RealmStage INT NOT NULL DEFAULT 0,
   CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
 );
 
@@ -146,7 +147,8 @@ GO
    6) Tạo 1 player mẫu để test
    ---------------------------- */
 DECLARE @pid UNIQUEIDENTIFIER = NEWID();
-INSERT INTO dbo.Players (PlayerId, Name, Realm) VALUES (@pid, N'Nguyeen_pro', N'phàm nhân');
+INSERT INTO dbo.Players (PlayerId, Name, Realm, RealmStage)
+VALUES (@pid, N'Nguyeen_pro', N'phàm nhân', 0);
 
 INSERT INTO dbo.PlayerBaseStats (PlayerId, Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength)
 VALUES (@pid, 5, 4, 100, 100, 5, 0, 1000, 1);

--- a/src/game/db/PlayerBaseStatsDao.java
+++ b/src/game/db/PlayerBaseStatsDao.java
@@ -1,0 +1,70 @@
+package game.db;
+
+import game.entity.attributes.Attributes;
+import game.enums.Attr;
+
+import java.sql.*;
+
+/** DAO for {@code PlayerBaseStats}. */
+public class PlayerBaseStatsDao {
+
+    /** DTO for base stats. */
+    public static class BaseStats {
+        public int atk;
+        public int def;
+        public int healthMax;
+        public int pepMax;
+        public int sould;
+        public int spirit;
+        public int spiritMax;
+        public int strength;
+    }
+
+    /** Load base stats for given player. */
+    public BaseStats load(String playerId) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB();
+             PreparedStatement ps = conn.prepareStatement(
+                     "SELECT Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength " +
+                     "FROM dbo.PlayerBaseStats WHERE PlayerId = ?")) {
+            ps.setString(1, playerId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    BaseStats bs = new BaseStats();
+                    bs.atk = rs.getInt("Atk");
+                    bs.def = rs.getInt("Def");
+                    bs.healthMax = rs.getInt("HealthMax");
+                    bs.pepMax = rs.getInt("PepMax");
+                    bs.sould = rs.getInt("Sould");
+                    bs.spirit = rs.getInt("Spirit");
+                    bs.spiritMax = rs.getInt("SpiritMax");
+                    bs.strength = rs.getInt("Strength");
+                    return bs;
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Upsert base stats for player. */
+    public void upsert(String playerId, Attributes atts) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB();
+             PreparedStatement ps = conn.prepareStatement(
+                     "MERGE dbo.PlayerBaseStats AS target " +
+                     "USING (SELECT ? AS PlayerId, ? AS Atk, ? AS Def, ? AS HealthMax, ? AS PepMax, ? AS Sould, ? AS Spirit, ? AS SpiritMax, ? AS Strength) AS src " +
+                     "ON target.PlayerId = src.PlayerId " +
+                     "WHEN MATCHED THEN UPDATE SET Atk=src.Atk, Def=src.Def, HealthMax=src.HealthMax, PepMax=src.PepMax, Sould=src.Sould, Spirit=src.Spirit, SpiritMax=src.SpiritMax, Strength=src.Strength " +
+                     "WHEN NOT MATCHED THEN INSERT (PlayerId, Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength) VALUES (src.PlayerId, src.Atk, src.Def, src.HealthMax, src.PepMax, src.Sould, src.Spirit, src.SpiritMax, src.Strength);")) {
+            ps.setString(1, playerId);
+            ps.setInt(2, atts.get(Attr.ATTACK));
+            ps.setInt(3, atts.get(Attr.DEF));
+            ps.setInt(4, atts.getMax(Attr.HEALTH));
+            ps.setInt(5, atts.getMax(Attr.PEP));
+            ps.setInt(6, atts.get(Attr.SOULD));
+            ps.setInt(7, atts.get(Attr.SPIRIT));
+            ps.setInt(8, atts.getMax(Attr.SPIRIT));
+            ps.setInt(9, atts.get(Attr.STRENGTH));
+            ps.executeUpdate();
+        }
+    }
+}
+

--- a/src/game/db/PlayerDao.java
+++ b/src/game/db/PlayerDao.java
@@ -3,6 +3,8 @@ package game.db;
 import java.sql.*;
 import java.time.LocalDateTime;
 
+import game.enums.Realm;
+
 /**
  * DAO for the {@code Players} table.
  */
@@ -15,6 +17,23 @@ public class PlayerDao {
         public int realmStage;
         public String physique;
         public LocalDateTime createdAt;
+
+        /**
+         * @return tên hiển thị đầy đủ của cảnh giới bao gồm cả tiểu cảnh giới,
+         *         ví dụ: "Luyện thể tầng 10".
+         */
+        public String getFullRealmName() {
+            if (realm == null) return null;
+            try {
+                Realm r = Realm.valueOf(realm);
+                return switch (r) {
+                    case PHAM_NHAN -> r.getDisplayName();
+                    default -> r.getDisplayName() + " tầng " + realmStage;
+                };
+            } catch (IllegalArgumentException ex) {
+                return realmStage > 0 ? realm + " tầng " + realmStage : realm;
+            }
+        }
     }
 
     /**

--- a/src/game/db/PlayerDao.java
+++ b/src/game/db/PlayerDao.java
@@ -1,0 +1,66 @@
+package game.db;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+
+/**
+ * DAO for the {@code Players} table.
+ */
+public class PlayerDao {
+
+    /** Simple DTO representing a row in {@code Players}. */
+    public static class PlayerRecord {
+        public String playerId;
+        public String realm;
+        public LocalDateTime createdAt;
+    }
+
+    /**
+     * Load a player by name.
+     *
+     * @param name player name
+     * @return record or {@code null} if not found
+     */
+    public PlayerRecord load(String name) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB();
+             PreparedStatement ps = conn.prepareStatement(
+                     "SELECT PlayerId, Realm, CreatedAt FROM dbo.Players WHERE Name = ?")) {
+            ps.setString(1, name);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    PlayerRecord rec = new PlayerRecord();
+                    rec.playerId = rs.getString("PlayerId");
+                    rec.realm = rs.getString("Realm");
+                    Timestamp ts = rs.getTimestamp("CreatedAt");
+                    rec.createdAt = ts != null ? ts.toLocalDateTime() : null;
+                    return rec;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Insert or update a player and return the {@code PlayerId}.
+     */
+    public String upsert(String name, String realm) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB();
+             PreparedStatement ps = conn.prepareStatement(
+                     "MERGE dbo.Players AS target " +
+                     "USING (SELECT ? AS Name, ? AS Realm) AS src " +
+                     "ON target.Name = src.Name " +
+                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm " +
+                     "WHEN NOT MATCHED THEN INSERT (Name, Realm) VALUES (src.Name, src.Realm) " +
+                     "OUTPUT inserted.PlayerId;")) {
+            ps.setString(1, name);
+            ps.setString(2, realm);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getString(1);
+                }
+            }
+        }
+        return null;
+    }
+}
+

--- a/src/game/db/PlayerDao.java
+++ b/src/game/db/PlayerDao.java
@@ -13,6 +13,7 @@ public class PlayerDao {
         public String playerId;
         public String realm;
         public int realmStage;
+        public String physique;
         public LocalDateTime createdAt;
     }
 
@@ -25,7 +26,7 @@ public class PlayerDao {
     public PlayerRecord load(String name) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
-                     "SELECT PlayerId, Realm, RealmStage, CreatedAt FROM dbo.Players WHERE Name = ?")) {
+                     "SELECT PlayerId, Realm, RealmStage, Physique, CreatedAt FROM dbo.Players WHERE Name = ?")) {
             ps.setString(1, name);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
@@ -33,6 +34,7 @@ public class PlayerDao {
                     rec.playerId = rs.getString("PlayerId");
                     rec.realm = rs.getString("Realm");
                     rec.realmStage = rs.getInt("RealmStage");
+                    rec.physique = rs.getString("Physique");
                     Timestamp ts = rs.getTimestamp("CreatedAt");
                     rec.createdAt = ts != null ? ts.toLocalDateTime() : null;
                     return rec;
@@ -45,18 +47,19 @@ public class PlayerDao {
     /**
      * Insert or update a player and return the {@code PlayerId}.
      */
-    public String upsert(String name, String realm, int realmStage) throws ClassNotFoundException, SQLException {
+    public String upsert(String name, String realm, int realmStage, String physique) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
                      "MERGE dbo.Players AS target " +
-                     "USING (SELECT ? AS Name, ? AS Realm, ? AS RealmStage) AS src " +
+                     "USING (SELECT ? AS Name, ? AS Realm, ? AS RealmStage, ? AS Physique) AS src " +
                      "ON target.Name = src.Name " +
-                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm, RealmStage = src.RealmStage " +
-                     "WHEN NOT MATCHED THEN INSERT (Name, Realm, RealmStage) VALUES (src.Name, src.Realm, src.RealmStage) " +
+                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm, RealmStage = src.RealmStage, Physique = src.Physique " +
+                     "WHEN NOT MATCHED THEN INSERT (Name, Realm, RealmStage, Physique) VALUES (src.Name, src.Realm, src.RealmStage, src.Physique) " +
                      "OUTPUT inserted.PlayerId;")) {
             ps.setString(1, name);
             ps.setString(2, realm);
             ps.setInt(3, realmStage);
+            ps.setString(4, physique);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     return rs.getString(1);

--- a/src/game/db/PlayerDao.java
+++ b/src/game/db/PlayerDao.java
@@ -12,6 +12,7 @@ public class PlayerDao {
     public static class PlayerRecord {
         public String playerId;
         public String realm;
+        public int realmStage;
         public LocalDateTime createdAt;
     }
 
@@ -24,13 +25,14 @@ public class PlayerDao {
     public PlayerRecord load(String name) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
-                     "SELECT PlayerId, Realm, CreatedAt FROM dbo.Players WHERE Name = ?")) {
+                     "SELECT PlayerId, Realm, RealmStage, CreatedAt FROM dbo.Players WHERE Name = ?")) {
             ps.setString(1, name);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     PlayerRecord rec = new PlayerRecord();
                     rec.playerId = rs.getString("PlayerId");
                     rec.realm = rs.getString("Realm");
+                    rec.realmStage = rs.getInt("RealmStage");
                     Timestamp ts = rs.getTimestamp("CreatedAt");
                     rec.createdAt = ts != null ? ts.toLocalDateTime() : null;
                     return rec;
@@ -43,17 +45,18 @@ public class PlayerDao {
     /**
      * Insert or update a player and return the {@code PlayerId}.
      */
-    public String upsert(String name, String realm) throws ClassNotFoundException, SQLException {
+    public String upsert(String name, String realm, int realmStage) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
                      "MERGE dbo.Players AS target " +
-                     "USING (SELECT ? AS Name, ? AS Realm) AS src " +
+                     "USING (SELECT ? AS Name, ? AS Realm, ? AS RealmStage) AS src " +
                      "ON target.Name = src.Name " +
-                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm " +
-                     "WHEN NOT MATCHED THEN INSERT (Name, Realm) VALUES (src.Name, src.Realm) " +
+                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm, RealmStage = src.RealmStage " +
+                     "WHEN NOT MATCHED THEN INSERT (Name, Realm, RealmStage) VALUES (src.Name, src.Realm, src.RealmStage) " +
                      "OUTPUT inserted.PlayerId;")) {
             ps.setString(1, name);
             ps.setString(2, realm);
+            ps.setInt(3, realmStage);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     return rs.getString(1);

--- a/src/game/db/PlayerRuntimeDao.java
+++ b/src/game/db/PlayerRuntimeDao.java
@@ -1,0 +1,49 @@
+package game.db;
+
+import java.sql.*;
+
+/** DAO for {@code PlayerRuntime}. */
+public class PlayerRuntimeDao {
+
+    /** DTO for runtime stats. */
+    public static class RuntimeStats {
+        public int currentHP;
+        public int currentPep;
+        public long money;
+    }
+
+    public RuntimeStats load(String playerId) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB();
+             PreparedStatement ps = conn.prepareStatement(
+                     "SELECT CurrentHP, CurrentPep, Money FROM dbo.PlayerRuntime WHERE PlayerId = ?")) {
+            ps.setString(1, playerId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    RuntimeStats rt = new RuntimeStats();
+                    rt.currentHP = rs.getInt("CurrentHP");
+                    rt.currentPep = rs.getInt("CurrentPep");
+                    rt.money = rs.getLong("Money");
+                    return rt;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void upsert(String playerId, int currentHP, int currentPep, long money) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB();
+             PreparedStatement ps = conn.prepareStatement(
+                     "MERGE dbo.PlayerRuntime AS target " +
+                     "USING (SELECT ? AS PlayerId, ? AS CurrentHP, ? AS CurrentPep, ? AS Money) AS src " +
+                     "ON target.PlayerId = src.PlayerId " +
+                     "WHEN MATCHED THEN UPDATE SET CurrentHP=src.CurrentHP, CurrentPep=src.CurrentPep, Money=src.Money " +
+                     "WHEN NOT MATCHED THEN INSERT (PlayerId, CurrentHP, CurrentPep, Money) VALUES (src.PlayerId, src.CurrentHP, src.CurrentPep, src.Money);")) {
+            ps.setString(1, playerId);
+            ps.setInt(2, currentHP);
+            ps.setInt(3, currentPep);
+            ps.setLong(4, money);
+            ps.executeUpdate();
+        }
+    }
+}
+

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -733,7 +733,7 @@ public class Player extends GameActor implements DrawableEntity {
     private void saveStats() {
         try {
             PlayerDao pdao = new PlayerDao();
-            playerId = pdao.upsert(getName(), realm.name(), realmStage);
+            playerId = pdao.upsert(getName(), realm.name(), realmStage, physique.name());
 
             PlayerBaseStatsDao bsDao = new PlayerBaseStatsDao();
             bsDao.upsert(playerId, baseAtts);
@@ -816,6 +816,9 @@ public class Player extends GameActor implements DrawableEntity {
                 try { realm = Realm.valueOf(rec.realm); } catch (IllegalArgumentException ignored) {}
             }
             realmStage = rec.realmStage;
+            if (rec.physique != null) {
+                try { physique = Physique.valueOf(rec.physique); } catch (IllegalArgumentException ignored) {}
+            }
             if (rec.createdAt != null) {
                 creationDate = rec.createdAt.toLocalDate();
             }

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -733,7 +733,7 @@ public class Player extends GameActor implements DrawableEntity {
     private void saveStats() {
         try {
             PlayerDao pdao = new PlayerDao();
-            playerId = pdao.upsert(getName(), realm.name());
+            playerId = pdao.upsert(getName(), realm.name(), realmStage);
 
             PlayerBaseStatsDao bsDao = new PlayerBaseStatsDao();
             bsDao.upsert(playerId, baseAtts);
@@ -815,6 +815,7 @@ public class Player extends GameActor implements DrawableEntity {
             if (rec.realm != null) {
                 try { realm = Realm.valueOf(rec.realm); } catch (IllegalArgumentException ignored) {}
             }
+            realmStage = rec.realmStage;
             if (rec.createdAt != null) {
                 creationDate = rec.createdAt.toLocalDate();
             }

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -44,6 +44,9 @@ import game.main.GamePanel;
 import game.util.CameraHelper;
 import game.util.UtilityTool;
 import game.db.DBAccount;
+import game.db.PlayerDao;
+import game.db.PlayerBaseStatsDao;
+import game.db.PlayerRuntimeDao;
 
 public class Player extends GameActor implements DrawableEntity {
 	// Vị trí nhân vật trên màn hình (luôn ở giữa)
@@ -70,6 +73,8 @@ public class Player extends GameActor implements DrawableEntity {
     // Cảnh giới hiện tại của người chơi
     private Realm realm = Realm.PHAM_NHAN;
     private int realmStage = 0;
+    /** PlayerId from SQL database. */
+    private String playerId;
     /**
      * Yêu cầu SPIRIT thực tế để lên cấp tiếp theo sau khi áp dụng hệ số thể chất.
      * Giá trị gốc trước khi áp dụng hệ số được lưu trong {@code baseSpiritRequirement}.
@@ -711,6 +716,7 @@ public class Player extends GameActor implements DrawableEntity {
 
     public synchronized void saveState() {
         logRealmState();
+        saveStats();
         saveProfile();
     }
 
@@ -721,6 +727,22 @@ public class Player extends GameActor implements DrawableEntity {
     public void stopAutoSave() {
         autoSaveExecutor.shutdownNow();
         saveState();
+    }
+
+    /** Persist core stats to SQL Server tables. */
+    private void saveStats() {
+        try {
+            PlayerDao pdao = new PlayerDao();
+            playerId = pdao.upsert(getName(), realm.name());
+
+            PlayerBaseStatsDao bsDao = new PlayerBaseStatsDao();
+            bsDao.upsert(playerId, baseAtts);
+
+            PlayerRuntimeDao rtDao = new PlayerRuntimeDao();
+            rtDao.upsert(playerId, baseAtts.get(Attr.HEALTH), baseAtts.get(Attr.PEP), 0);
+        } catch (ClassNotFoundException | SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     /** Persist current player profile to SQL Server. */
@@ -785,86 +807,122 @@ public class Player extends GameActor implements DrawableEntity {
 
     /** Load player profile from SQL Server. */
     private boolean loadProfile() {
-        try (Connection conn = DBAccount.getConnectDB();
-             PreparedStatement ps = conn.prepareStatement(
-                     "SELECT profile FROM " + PROFILE_TABLE + " WHERE name = ?")) {
-            ps.setString(1, getName());
-            try (ResultSet rs = ps.executeQuery()) {
-                if (!rs.next()) return false;
-                String profileData = rs.getString("profile");
-                List<String> lines = Arrays.asList(profileData.split("\\r?\\n"));
-                int idxLine = 0;
+        try {
+            PlayerDao pdao = new PlayerDao();
+            PlayerDao.PlayerRecord rec = pdao.load(getName());
+            if (rec == null) return false;
+            playerId = rec.playerId;
+            if (rec.realm != null) {
+                try { realm = Realm.valueOf(rec.realm); } catch (IllegalArgumentException ignored) {}
+            }
+            if (rec.createdAt != null) {
+                creationDate = rec.createdAt.toLocalDate();
+            }
 
-                if (idxLine < lines.size() && lines.get(idxLine).startsWith("CREATION_DATE:")) {
-                    String dateStr = lines.get(idxLine).substring("CREATION_DATE:".length()).trim();
-                    creationDate = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
-                    idxLine++;
-                }
+            PlayerBaseStatsDao bsDao = new PlayerBaseStatsDao();
+            PlayerBaseStatsDao.BaseStats bs = bsDao.load(playerId);
+            if (bs == null) return false;
+            baseAtts.set(Attr.ATTACK, bs.atk);
+            baseAtts.set(Attr.DEF, bs.def);
+            baseAtts.setMax(Attr.HEALTH, bs.healthMax);
+            baseAtts.setMax(Attr.PEP, bs.pepMax);
+            baseAtts.set(Attr.SOULD, bs.sould);
+            baseAtts.set(Attr.SPIRIT, bs.spirit);
+            baseAtts.setMax(Attr.SPIRIT, bs.spiritMax);
+            baseAtts.set(Attr.STRENGTH, bs.strength);
+            baseSpiritRequirement = bs.spiritMax;
+            spiritToNextLevel = bs.spiritMax;
 
-                if (idxLine < lines.size()) {
-                    String itemLine = lines.get(idxLine);
-                    String prefix = "Itemcủa nhân vật: ";
-                    if (itemLine.startsWith(prefix)) {
-                        String items = itemLine.substring(prefix.length()).trim();
-                        bag.clear();
-                        if (!items.isEmpty()) {
-                            String[] tokens = items.split(",\\s*");
-                            for (String token : tokens) {
-                                int idxTok = token.lastIndexOf(" (");
-                                int end = token.lastIndexOf(")");
-                                if (idxTok > 0 && end > idxTok) {
-                                    String name = token.substring(0, idxTok).trim();
-                                    int qty = Integer.parseInt(token.substring(idxTok + 2, end));
-                                    Item it = createItemByName(name, qty);
-                                    if (it != null) bag.add(it);
+            PlayerRuntimeDao rtDao = new PlayerRuntimeDao();
+            PlayerRuntimeDao.RuntimeStats rt = rtDao.load(playerId);
+            if (rt != null) {
+                baseAtts.set(Attr.HEALTH, rt.currentHP);
+                baseAtts.set(Attr.PEP, rt.currentPep);
+            }
+
+            // Load inventory/equipment from serialized profile if present
+            try (Connection conn = DBAccount.getConnectDB();
+                 PreparedStatement ps = conn.prepareStatement(
+                         "SELECT profile FROM " + PROFILE_TABLE + " WHERE name = ?")) {
+                ps.setString(1, getName());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        String profileData = rs.getString("profile");
+                        List<String> lines = Arrays.asList(profileData.split("\\r?\\n"));
+                        int idxLine = 0;
+
+                        if (idxLine < lines.size() && lines.get(idxLine).startsWith("CREATION_DATE:")) {
+                            String dateStr = lines.get(idxLine).substring("CREATION_DATE:".length()).trim();
+                            creationDate = LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+                            idxLine++;
+                        }
+
+                        if (idxLine < lines.size()) {
+                            String itemLine = lines.get(idxLine);
+                            String prefix = "Itemcủa nhân vật: ";
+                            if (itemLine.startsWith(prefix)) {
+                                String items = itemLine.substring(prefix.length()).trim();
+                                bag.clear();
+                                if (!items.isEmpty()) {
+                                    String[] tokens = items.split(",\\s*");
+                                    for (String token : tokens) {
+                                        int idxTok = token.lastIndexOf(" (");
+                                        int end = token.lastIndexOf(")");
+                                        if (idxTok > 0 && end > idxTok) {
+                                            String name = token.substring(0, idxTok).trim();
+                                            int qty = Integer.parseInt(token.substring(idxTok + 2, end));
+                                            Item it = createItemByName(name, qty);
+                                            if (it != null) bag.add(it);
+                                        }
+                                    }
                                 }
                             }
+                            idxLine++;
                         }
-                    }
-                    idxLine++;
-                }
 
-                if (idxLine < lines.size() && lines.get(idxLine).trim().equals("===EQUIPMENT===")) {
-                    idxLine++;
-                    equipment.clear();
-                    while (idxLine < lines.size()) {
-                        String line = lines.get(idxLine).trim();
-                        if (!line.startsWith("-")) break;
-                        line = line.substring(1).trim();
-                        int colon = line.indexOf(":");
-                        if (colon < 0) { idxLine++; continue; }
-                        String slotName = line.substring(0, colon).trim();
-                        String data = line.substring(colon + 1).trim();
-                        EquipSlot slot;
-                        try {
-                            slot = EquipSlot.valueOf(slotName);
-                        } catch (IllegalArgumentException e) {
-                            idxLine++; continue;
+                        if (idxLine < lines.size() && lines.get(idxLine).trim().equals("===EQUIPMENT===")) {
+                            idxLine++;
+                            equipment.clear();
+                            while (idxLine < lines.size()) {
+                                String line = lines.get(idxLine).trim();
+                                if (!line.startsWith("-")) break;
+                                line = line.substring(1).trim();
+                                int colon = line.indexOf(":");
+                                if (colon < 0) { idxLine++; continue; }
+                                String slotName = line.substring(0, colon).trim();
+                                String data = line.substring(colon + 1).trim();
+                                EquipSlot slot;
+                                try {
+                                    slot = EquipSlot.valueOf(slotName);
+                                } catch (IllegalArgumentException e) {
+                                    idxLine++; continue;
+                                }
+                                if (!data.equalsIgnoreCase("none")) {
+                                    String[] partsEq = data.split("\\|");
+                                    String id = partsEq.length > 0 ? partsEq[0].trim() : "";
+                                    String nameEq = partsEq.length > 1 ? partsEq[1].trim() : "";
+                                    String descEq = partsEq.length > 2 ? partsEq[2].trim() : "";
+                                    EquipmentItem eq = createEquipmentFromSlot(id, nameEq, descEq, slot);
+                                    if (eq != null) {
+                                        equipment.put(slot, eq);
+                                        if (eq.getType() == EquipType.RING) bag.increaseCapacity(10);
+                                    }
+                                }
+                                idxLine++;
+                            }
+                            refreshStats();
                         }
-                        if (!data.equalsIgnoreCase("none")) {
-                            String[] partsEq = data.split("\\|");
-                            String id = partsEq.length > 0 ? partsEq[0].trim() : "";
-                            String nameEq = partsEq.length > 1 ? partsEq[1].trim() : "";
-                            String descEq = partsEq.length > 2 ? partsEq[2].trim() : "";
-                            EquipmentItem eq = createEquipmentFromSlot(id, nameEq, descEq, slot);
-                            if (eq != null) {
-                                equipment.put(slot, eq);
-                                if (eq.getType() == EquipType.RING) bag.increaseCapacity(10);
+
+                        if (idxLine < lines.size()) {
+                            realmLog.clear();
+                            for (; idxLine < lines.size(); idxLine++) {
+                                realmLog.add(lines.get(idxLine));
                             }
                         }
-                        idxLine++;
-                    }
-                    refreshStats();
-                }
-
-                if (idxLine < lines.size()) {
-                    realmLog.clear();
-                    for (; idxLine < lines.size(); idxLine++) {
-                        realmLog.add(lines.get(idxLine));
                     }
                 }
-                return true;
             }
+            return true;
         } catch (ClassNotFoundException | SQLException e) {
             e.printStackTrace();
             return false;


### PR DESCRIPTION
## Summary
- add JDBC DAO classes for Players, PlayerBaseStats and PlayerRuntime tables
- refactor Player to save and load core attributes through the new DAOs
- document database persistence for player stats

## Testing
- `javac $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68af245de120832fa61222c5472cd64e