### PR TITLE
feat: persist player location

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -113,3 +113,7 @@ Sửa lỗi và cải tiến:
 ## 1.0.27
 - Thêm bảng `PlayerTechniques` lưu công pháp đã học.
 - `PlayerSkillDao` và `Player` đọc/ghi công pháp vào database.
+
+## 1.0.28
+- Bảng `PlayerRuntime` lưu thêm thông tin bản đồ (`MapId`) và tọa độ (`PosX`, `PosY`).
+- `PlayerRuntimeDao` và `Player` đọc/ghi vị trí hiện tại của nhân vật.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 	
 ## Tính năng
 
-- Thuộc tính nhân vật được lưu vào SQL Server thông qua các bảng `Players` (cảnh giới, thể chất), `PlayerBaseStats`, `PlayerRuntime` và `PlayerTechniques`.
+- Thuộc tính và vị trí nhân vật được lưu vào SQL Server thông qua các bảng `Players` (cảnh giới, thể chất), `PlayerBaseStats`, `PlayerRuntime` (HP, Pep, bản đồ, tọa độ) và `PlayerTechniques`.
 
 ## Cập nhật
 
@@ -46,6 +46,12 @@
 ### Thêm
 - Bảng `PlayerTechniques` lưu danh sách công pháp đã học của người chơi.
 - `PlayerSkillDao` và `Player` đọc/ghi công pháp vào database.
+
+## [1.0.28]
+
+### Thêm
+- Bảng `PlayerRuntime` lưu thêm `MapId`, `PosX`, `PosY` để ghi nhận vị trí và bản đồ hiện tại của người chơi.
+- `PlayerRuntimeDao` và `Player` đọc/ghi các giá trị này khi lưu hoặc tải nhân vật.
 
 ## [1.0.20]
 

--- a/sql/game_db_core_schema.sql
+++ b/sql/game_db_core_schema.sql
@@ -45,6 +45,9 @@ CREATE TABLE dbo.PlayerRuntime (
   PlayerId UNIQUEIDENTIFIER NOT NULL CONSTRAINT PK_PlayerRuntime PRIMARY KEY,
   CurrentHP INT NOT NULL,
   CurrentPep INT NOT NULL,
+  MapId NVARCHAR(64) NOT NULL,
+  PosX INT NOT NULL,
+  PosY INT NOT NULL,
   Money BIGINT NOT NULL DEFAULT 0,
   CONSTRAINT FK_Runtime_Player FOREIGN KEY (PlayerId)
     REFERENCES dbo.Players(PlayerId) ON DELETE CASCADE
@@ -162,8 +165,8 @@ INSERT INTO dbo.Players (PlayerId, Name, Realm) VALUES (@pid, N'Nguyeen_pro', N'
 INSERT INTO dbo.PlayerBaseStats (PlayerId, Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength)
 VALUES (@pid, 5, 4, 100, 100, 5, 0, 1000, 1);
 
-INSERT INTO dbo.PlayerRuntime (PlayerId, CurrentHP, CurrentPep, Money)
-VALUES (@pid, 100, 100, 0);
+INSERT INTO dbo.PlayerRuntime (PlayerId, CurrentHP, CurrentPep, MapId, PosX, PosY, Money)
+VALUES (@pid, 100, 100, N'world01', 100, 100, 0);
 
 -- Techniques: sample skill
 INSERT INTO dbo.PlayerTechniques (PlayerId, Name, Grade, Level, SpiritPerSecond)

--- a/src/game/db/PlayerRuntimeDao.java
+++ b/src/game/db/PlayerRuntimeDao.java
@@ -10,12 +10,17 @@ public class PlayerRuntimeDao {
         public int currentHP;
         public int currentPep;
         public long money;
+        /** Identifier of the current map the player is in. */
+        public String mapId;
+        /** Player position within the map. */
+        public int posX;
+        public int posY;
     }
 
     public RuntimeStats load(String playerId) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
-                     "SELECT CurrentHP, CurrentPep, Money FROM dbo.PlayerRuntime WHERE PlayerId = ?")) {
+                     "SELECT CurrentHP, CurrentPep, Money, MapId, PosX, PosY FROM dbo.PlayerRuntime WHERE PlayerId = ?")) {
             ps.setString(1, playerId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
@@ -23,6 +28,9 @@ public class PlayerRuntimeDao {
                     rt.currentHP = rs.getInt("CurrentHP");
                     rt.currentPep = rs.getInt("CurrentPep");
                     rt.money = rs.getLong("Money");
+                    rt.mapId = rs.getString("MapId");
+                    rt.posX = rs.getInt("PosX");
+                    rt.posY = rs.getInt("PosY");
                     return rt;
                 }
             }
@@ -30,18 +38,22 @@ public class PlayerRuntimeDao {
         return null;
     }
 
-    public void upsert(String playerId, int currentHP, int currentPep, long money) throws ClassNotFoundException, SQLException {
+    public void upsert(String playerId, int currentHP, int currentPep, long money,
+                        String mapId, int posX, int posY) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
                      "MERGE dbo.PlayerRuntime AS target " +
-                     "USING (SELECT ? AS PlayerId, ? AS CurrentHP, ? AS CurrentPep, ? AS Money) AS src " +
+                     "USING (SELECT ? AS PlayerId, ? AS CurrentHP, ? AS CurrentPep, ? AS Money, ? AS MapId, ? AS PosX, ? AS PosY) AS src " +
                      "ON target.PlayerId = src.PlayerId " +
-                     "WHEN MATCHED THEN UPDATE SET CurrentHP=src.CurrentHP, CurrentPep=src.CurrentPep, Money=src.Money " +
-                     "WHEN NOT MATCHED THEN INSERT (PlayerId, CurrentHP, CurrentPep, Money) VALUES (src.PlayerId, src.CurrentHP, src.CurrentPep, src.Money);")) {
+                     "WHEN MATCHED THEN UPDATE SET CurrentHP=src.CurrentHP, CurrentPep=src.CurrentPep, Money=src.Money, MapId=src.MapId, PosX=src.PosX, PosY=src.PosY " +
+                     "WHEN NOT MATCHED THEN INSERT (PlayerId, CurrentHP, CurrentPep, Money, MapId, PosX, PosY) VALUES (src.PlayerId, src.CurrentHP, src.CurrentPep, src.Money, src.MapId, src.PosX, src.PosY);")) {
             ps.setString(1, playerId);
             ps.setInt(2, currentHP);
             ps.setInt(3, currentPep);
             ps.setLong(4, money);
+            ps.setString(5, mapId);
+            ps.setInt(6, posX);
+            ps.setInt(7, posY);
             ps.executeUpdate();
         }
     }

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -117,6 +117,9 @@ public class Player extends GameActor implements DrawableEntity {
     private int pillSpiritBonus = 0;
     private long pillBuffEnd = 0;
 
+    /** Identifier of the current map the player is located in. */
+    private String mapId = "world01";
+
 	public Player(GamePanel gp) {
 		super(gp);
         this.screenX = gp.getScreenWidth() / 2 - (gp.getTileSize() / 2);//360
@@ -740,7 +743,8 @@ public class Player extends GameActor implements DrawableEntity {
             bsDao.upsert(playerId, baseAtts);
 
             PlayerRuntimeDao rtDao = new PlayerRuntimeDao();
-            rtDao.upsert(playerId, baseAtts.get(Attr.HEALTH), baseAtts.get(Attr.PEP), 0);
+            rtDao.upsert(playerId, baseAtts.get(Attr.HEALTH), baseAtts.get(Attr.PEP), 0,
+                    mapId, getWorldX(), getWorldY());
 
             PlayerSkillDao skDao = new PlayerSkillDao();
             skDao.replaceAll(playerId, techniques);
@@ -846,6 +850,11 @@ public class Player extends GameActor implements DrawableEntity {
             if (rt != null) {
                 baseAtts.set(Attr.HEALTH, rt.currentHP);
                 baseAtts.set(Attr.PEP, rt.currentPep);
+                setWorldX(rt.posX);
+                setWorldY(rt.posY);
+                if (rt.mapId != null) {
+                    mapId = rt.mapId;
+                }
             }
 
             PlayerSkillDao skDao = new PlayerSkillDao();


### PR DESCRIPTION
## Summary
- store player map and coordinates in PlayerRuntime table
- load/save map and position via PlayerRuntimeDao and Player
- document database schema and change log updates

## Testing
- `javac -d bin @sources.list`


------
https://chatgpt.com/codex/tasks/task_e_68b05d5743a0832f9546edff8fcc2423