### PR TITLE
feat: dynamic map sizing and database integration

### DIFF
--- a/sql/game_db_core_schema.sql
+++ b/sql/game_db_core_schema.sql
@@ -52,10 +52,38 @@ CREATE TABLE dbo.PlayerRuntime (
 );
 GO
 
-ALTER TABLE dbo.PlayerRuntime 
+IF OBJECT_ID('dbo.Maps','U') IS NOT NULL DROP TABLE dbo.Maps;
+GO
+
+CREATE TABLE dbo.Maps (
+  MapId NVARCHAR(64) NOT NULL CONSTRAINT PK_Maps PRIMARY KEY,
+  Name NVARCHAR(128) NOT NULL,
+  Info NVARCHAR(MAX) NULL
+);
+GO
+
+IF OBJECT_ID('dbo.MapAccess','U') IS NOT NULL DROP TABLE dbo.MapAccess;
+GO
+
+CREATE TABLE dbo.MapAccess (
+  MapId NVARCHAR(64) NOT NULL,
+  PlayerId UNIQUEIDENTIFIER NOT NULL,
+  CONSTRAINT PK_MapAccess PRIMARY KEY (MapId, PlayerId),
+  CONSTRAINT FK_MapAccess_Maps FOREIGN KEY (MapId)
+    REFERENCES dbo.Maps(MapId) ON DELETE CASCADE,
+  CONSTRAINT FK_MapAccess_Player FOREIGN KEY (PlayerId)
+    REFERENCES dbo.Players(PlayerId) ON DELETE CASCADE
+);
+GO
+
+ALTER TABLE dbo.PlayerRuntime
   ADD MapId NVARCHAR(64) NOT NULL DEFAULT N'unknown',
       PosX  INT NOT NULL DEFAULT 0,
       PosY  INT NOT NULL DEFAULT 0;
+
+ALTER TABLE dbo.PlayerRuntime
+  ADD CONSTRAINT FK_PlayerRuntime_Map FOREIGN KEY (MapId)
+    REFERENCES dbo.Maps(MapId);
 
 /* ----------------------------
    2) Items & Stat Mods

--- a/src/game/db/MapDao.java
+++ b/src/game/db/MapDao.java
@@ -1,0 +1,31 @@
+package game.db;
+
+import java.sql.*;
+
+/**
+ * DAO for map metadata.
+ */
+public class MapDao {
+
+    /** Ensure a map record exists; insert if missing. */
+    public void ensureExists(String mapId, String name, String info) throws ClassNotFoundException, SQLException {
+        try (Connection conn = DBAccount.getConnectDB()) {
+            try (PreparedStatement check = conn.prepareStatement(
+                    "SELECT 1 FROM dbo.Maps WHERE MapId = ?")) {
+                check.setString(1, mapId);
+                try (ResultSet rs = check.executeQuery()) {
+                    if (rs.next()) {
+                        return; // already exists
+                    }
+                }
+            }
+            try (PreparedStatement insert = conn.prepareStatement(
+                    "INSERT INTO dbo.Maps(MapId, Name, Info) VALUES(?,?,?)")) {
+                insert.setString(1, mapId);
+                insert.setString(2, name);
+                insert.setString(3, info);
+                insert.executeUpdate();
+            }
+        }
+    }
+}

--- a/src/game/main/GamePanel.java
+++ b/src/game/main/GamePanel.java
@@ -35,12 +35,12 @@ public class GamePanel extends JPanel implements Runnable {
 	//Tổng số độ dài khung hình hiển thị
 	private final int screenWidth = tileSize * maxScreenCol;//768
 	private final int screenHeight = tileSize * maxScreenRow;//576
-	// Tổng cột và hàng trong map
-	private final int maxWorldCol = 50;
-	private final int maxWorldRow = 50;
-	// Tổng số chiều rộng và chiều cao trong map(pixel)
-	private final int worldWidth = tileSize * maxWorldCol;//2400
-	private final int worldHeight = tileSize * maxWorldRow;
+        // Tổng cột và hàng trong map (sẽ được thiết lập khi tải bản đồ)
+        private int maxWorldCol;
+        private int maxWorldRow;
+        // Tổng số chiều rộng và chiều cao trong map(pixel)
+        private int worldWidth;
+        private int worldHeight;
 	private Thread thread;
 	private int FPS = 60;
 	public KeyHandler keyH = new KeyHandler(this);
@@ -173,11 +173,17 @@ public class GamePanel extends JPanel implements Runnable {
 	public int getMaxScreenCol() { return maxScreenCol; }
 	public int getMaxScreenRow() { return maxScreenRow; }
 	public int getScreenWidth() { return screenWidth; }
-	public int getScreenHeight() { return screenHeight; }
-	public int getMaxWorldCol() { return maxWorldCol; }
-	public int getMaxWorldRow() { return maxWorldRow; }
-	public int getWorldWidth() { return worldWidth; }
-	public int getWorldHeight() { return worldHeight; }
+        public int getScreenHeight() { return screenHeight; }
+        public int getMaxWorldCol() { return maxWorldCol; }
+        public int getMaxWorldRow() { return maxWorldRow; }
+        public int getWorldWidth() { return worldWidth; }
+        public int getWorldHeight() { return worldHeight; }
+        public void setWorldSize(int cols, int rows) {
+            this.maxWorldCol = cols;
+            this.maxWorldRow = rows;
+            this.worldWidth = tileSize * cols;
+            this.worldHeight = tileSize * rows;
+        }
 	public Player getPlayer() { return player; }
 	public TileManager getTileManager() { return tileManager; }
 	public CollisionChecker getCheckCollision() { return checkCollision; }

--- a/src/game/tile/GameMap.java
+++ b/src/game/tile/GameMap.java
@@ -1,0 +1,42 @@
+package game.tile;
+
+/**
+ * Represents a tile-based map loaded from a resource file.
+ */
+public class GameMap {
+    private final String id;
+    private final String name;
+    private final String info;
+    private final int[][] tileNumbers;
+
+    public GameMap(String id, String name, String info, int[][] tileNumbers) {
+        this.id = id;
+        this.name = name;
+        this.info = info;
+        this.tileNumbers = tileNumbers;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getInfo() {
+        return info;
+    }
+
+    public int[][] getTileNumbers() {
+        return tileNumbers;
+    }
+
+    public int getCols() {
+        return tileNumbers.length;
+    }
+
+    public int getRows() {
+        return tileNumbers[0].length;
+    }
+}

--- a/src/game/tile/TileManager.java
+++ b/src/game/tile/TileManager.java
@@ -6,27 +6,33 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.imageio.ImageIO;
 
 import game.main.GamePanel;
 import game.util.UtilityTool;
+import game.db.MapDao;
 
 public class TileManager {
 	private final GamePanel gp;
-	private final Tile[] tile;
-	// Mảng lưu số hiệu của từng tile trong bản đồ
-	private final int [][] mapTileNumber;
+        private final Tile[] tile;
+        // Mảng lưu bản đồ theo id
+        private final Map<String, GameMap> maps = new HashMap<>();
+        private GameMap currentMap;
+        private int [][] mapTileNumber;
 	
 	// Contructor
 	public TileManager(GamePanel gp) {
 		this.gp = gp;
-		this.tile = new Tile[30];
-		this.mapTileNumber = new int[gp.getMaxWorldCol()][gp.getMaxWorldRow()];
-		
-		getTileImage();
-		loadMap("/data/map/world01.txt");
+                this.tile = new Tile[30];
+
+                getTileImage();
+                loadMap("world01", "World 01", "", "/data/map/world01.txt");
 	}
 	
 	public void getTileImage() {
@@ -73,28 +79,56 @@ public class TileManager {
         }
     }
 	
-    public void loadMap(String mapPath) {
+    public void loadMap(String mapId, String name, String info, String mapPath) {
         try {
             InputStream inputStream = getClass().getResourceAsStream(mapPath);
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-            int col = 0;
-            int row = 0;
-            while (col < gp.getMaxWorldCol() && row < gp.getMaxWorldRow()) {
-                String line = bufferedReader.readLine();
-                while (col < gp.getMaxWorldCol()) {
-                    String[] numbers = line.split(" ");
-                    int number = Integer.parseInt(numbers[col]);
-                    mapTileNumber[col][row] = number;
-                    col++;
-                }
-                if (col == gp.getMaxWorldCol()) {
-                    col = 0;
-                    row++;
+            List<String> lines = new ArrayList<>();
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                line = line.trim();
+                if (!line.isEmpty()) {
+                    lines.add(line);
                 }
             }
             bufferedReader.close();
+
+            int rows = lines.size();
+            int cols = lines.get(0).split(" ").length;
+            mapTileNumber = new int[cols][rows];
+            for (int row = 0; row < rows; row++) {
+                String[] numbers = lines.get(row).split(" ");
+                for (int col = 0; col < cols; col++) {
+                    mapTileNumber[col][row] = Integer.parseInt(numbers[col]);
+                }
+            }
+
+            GameMap map = new GameMap(mapId, name, info, mapTileNumber);
+            maps.put(mapId, map);
+            currentMap = map;
+            gp.setWorldSize(cols, rows);
+
+            // ensure map exists in DB
+            try {
+                MapDao dao = new MapDao();
+                dao.ensureExists(mapId, name, info);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    /**
+     * Switch to an already loaded map by its identifier.
+     */
+    public void setCurrentMap(String mapId) {
+        GameMap map = maps.get(mapId);
+        if (map != null) {
+            currentMap = map;
+            mapTileNumber = map.getTileNumbers();
+            gp.setWorldSize(map.getCols(), map.getRows());
         }
     }
 	
@@ -158,6 +192,7 @@ public class TileManager {
    
    public Tile[] getTile() { return tile; }
    public int[][] getMapTileNumber() { return mapTileNumber; }
+   public GameMap getCurrentMap() { return currentMap; }
 }
 
 


### PR DESCRIPTION
## Summary
- compute world dimensions from map files and expose `setWorldSize`
- refactor tile manager to load multiple maps and ensure map data exists in SQL
- add map DAO and schema for map metadata/access control

## Testing
- `javac -d /tmp/out @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b0bd5ef940832f84813dceb96e5c99