### PR TITLE
Ensure runtime player stats persist on exit

### DIFF
--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -719,6 +719,9 @@ public class Player extends GameActor implements DrawableEntity {
     }
 
     public synchronized void saveState() {
+        // Sync runtime attributes before persisting
+        baseAtts.set(Attr.HEALTH, atts().get(Attr.HEALTH));
+        baseAtts.set(Attr.PEP, atts().get(Attr.PEP));
         logRealmState();
         saveStats();
         saveProfile();
@@ -743,7 +746,7 @@ public class Player extends GameActor implements DrawableEntity {
             bsDao.upsert(playerId, baseAtts);
 
             PlayerRuntimeDao rtDao = new PlayerRuntimeDao();
-            rtDao.upsert(playerId, baseAtts.get(Attr.HEALTH), baseAtts.get(Attr.PEP), 0,
+            rtDao.upsert(playerId, atts().get(Attr.HEALTH), atts().get(Attr.PEP), 0,
                     mapId, getWorldX(), getWorldY());
 
             PlayerSkillDao skDao = new PlayerSkillDao();


### PR DESCRIPTION
## Summary
- Sync player runtime HP/PEP with base stats before saving
- Save current HP/PEP values to PlayerRuntime table when game exits

## Testing
- `javac -d out @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68b3b8e133cc832f8732fe2e4e83f432