### PR TITLE
Persist player affinities in database

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -117,3 +117,7 @@ Sửa lỗi và cải tiến:
 ## 1.0.28
 - Bảng `PlayerRuntime` lưu thêm thông tin bản đồ (`MapId`) và tọa độ (`PosX`, `PosY`).
 - `PlayerRuntimeDao` và `Player` đọc/ghi vị trí hiện tại của nhân vật.
+
+## 1.0.29
+- Bảng `Players` lưu thêm cột `Affinity` để ghi nhận linh căn của người chơi.
+- Bảng thuộc tính nhân vật hiển thị "Linh căn" dựa trên dữ liệu này.

--- a/sql/game_db_core_schema.sql
+++ b/sql/game_db_core_schema.sql
@@ -24,6 +24,9 @@ CREATE TABLE dbo.Players (
   PlayerId UNIQUEIDENTIFIER NOT NULL CONSTRAINT PK_Players PRIMARY KEY DEFAULT NEWID(),
   Name NVARCHAR(64) NOT NULL UNIQUE,
   Realm NVARCHAR(64) NULL,
+  RealmStage INT NOT NULL DEFAULT 0,
+  Physique NVARCHAR(64) NULL,
+  Affinity NVARCHAR(128) NULL,
   CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
 );
 
@@ -160,7 +163,8 @@ GO
    6) Tạo 1 player mẫu để test
    ---------------------------- */
 DECLARE @pid UNIQUEIDENTIFIER = NEWID();
-INSERT INTO dbo.Players (PlayerId, Name, Realm) VALUES (@pid, N'Nguyeen_pro', N'phàm nhân');
+INSERT INTO dbo.Players (PlayerId, Name, Realm, RealmStage, Physique, Affinity)
+VALUES (@pid, N'Nguyeen_pro', N'phàm nhân', 0, NULL, NULL);
 
 INSERT INTO dbo.PlayerBaseStats (PlayerId, Atk, Def, HealthMax, PepMax, Sould, Spirit, SpiritMax, Strength)
 VALUES (@pid, 5, 4, 100, 100, 5, 0, 1000, 1);

--- a/src/game/db/PlayerDao.java
+++ b/src/game/db/PlayerDao.java
@@ -16,6 +16,7 @@ public class PlayerDao {
         public String realm;
         public int realmStage;
         public String physique;
+        public String affinity;
         public LocalDateTime createdAt;
 
         /**
@@ -45,7 +46,7 @@ public class PlayerDao {
     public PlayerRecord load(String name) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
-                     "SELECT PlayerId, Realm, RealmStage, Physique, CreatedAt FROM dbo.Players WHERE Name = ?")) {
+                     "SELECT PlayerId, Realm, RealmStage, Physique, Affinity, CreatedAt FROM dbo.Players WHERE Name = ?")) {
             ps.setString(1, name);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
@@ -54,6 +55,7 @@ public class PlayerDao {
                     rec.realm = rs.getString("Realm");
                     rec.realmStage = rs.getInt("RealmStage");
                     rec.physique = rs.getString("Physique");
+                    rec.affinity = rs.getString("Affinity");
                     Timestamp ts = rs.getTimestamp("CreatedAt");
                     rec.createdAt = ts != null ? ts.toLocalDateTime() : null;
                     return rec;
@@ -66,19 +68,20 @@ public class PlayerDao {
     /**
      * Insert or update a player and return the {@code PlayerId}.
      */
-    public String upsert(String name, String realm, int realmStage, String physique) throws ClassNotFoundException, SQLException {
+    public String upsert(String name, String realm, int realmStage, String physique, String affinity) throws ClassNotFoundException, SQLException {
         try (Connection conn = DBAccount.getConnectDB();
              PreparedStatement ps = conn.prepareStatement(
                      "MERGE dbo.Players AS target " +
-                     "USING (SELECT ? AS Name, ? AS Realm, ? AS RealmStage, ? AS Physique) AS src " +
+                     "USING (SELECT ? AS Name, ? AS Realm, ? AS RealmStage, ? AS Physique, ? AS Affinity) AS src " +
                      "ON target.Name = src.Name " +
-                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm, RealmStage = src.RealmStage, Physique = src.Physique " +
-                     "WHEN NOT MATCHED THEN INSERT (Name, Realm, RealmStage, Physique) VALUES (src.Name, src.Realm, src.RealmStage, src.Physique) " +
+                     "WHEN MATCHED THEN UPDATE SET Realm = src.Realm, RealmStage = src.RealmStage, Physique = src.Physique, Affinity = src.Affinity " +
+                     "WHEN NOT MATCHED THEN INSERT (Name, Realm, RealmStage, Physique, Affinity) VALUES (src.Name, src.Realm, src.RealmStage, src.Physique, src.Affinity) " +
                      "OUTPUT inserted.PlayerId;")) {
             ps.setString(1, name);
             ps.setString(2, realm);
             ps.setInt(3, realmStage);
             ps.setString(4, physique);
+            ps.setString(5, affinity);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     return rs.getString(1);

--- a/src/game/entity/Player.java
+++ b/src/game/entity/Player.java
@@ -740,7 +740,7 @@ public class Player extends GameActor implements DrawableEntity {
     private void saveStats() {
         try {
             PlayerDao pdao = new PlayerDao();
-            playerId = pdao.upsert(getName(), realm.name(), realmStage, physique.name());
+            playerId = pdao.upsert(getName(), realm.name(), realmStage, physique.name(), getAffinityNames());
 
             PlayerBaseStatsDao bsDao = new PlayerBaseStatsDao();
             bsDao.upsert(playerId, baseAtts);
@@ -829,6 +829,9 @@ public class Player extends GameActor implements DrawableEntity {
             realmStage = rec.realmStage;
             if (rec.physique != null) {
                 try { physique = Physique.valueOf(rec.physique); } catch (IllegalArgumentException ignored) {}
+            }
+            if (rec.affinity != null) {
+                affinities = parseAffinities(rec.affinity);
             }
             if (rec.createdAt != null) {
                 creationDate = rec.createdAt.toLocalDate();

--- a/src/game/ui/InventoryUi.java
+++ b/src/game/ui/InventoryUi.java
@@ -342,7 +342,7 @@ public class InventoryUi {
         var phys = p.getPhysique();
         String physName = (phys != null) ? phys.getDisplay() : "Unknown";
         g2.drawString("Physique: " + physName, textX, textY); textY += 15;
-        g2.drawString("Affinity: " + p.getAffinityNames(), textX, textY); textY += 20;
+        g2.drawString("Linh căn: " + p.getAffinityNames(), textX, textY); textY += 20;
 
         // Vẽ nút mở bảng công pháp
         int btnW = gp.getTileSize() * 3;


### PR DESCRIPTION
## Summary
- Track player spiritual roots via new `Affinity` column in `Players` schema and example seed
- Save and load affinity data through `PlayerDao` and `Player`
- Display "Linh căn" on the character attribute panel

## Testing
- `javac -d /tmp/out @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68b3c9208c10832fbbd8c35385986b1f